### PR TITLE
Minor style improvements

### DIFF
--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -123,7 +123,7 @@ namespace PortingAssistant.Client.Analysis
                     ProjectFilePath = analyzer.ProjectResult.ProjectFilePath,
                     TargetFrameworks = targetframeworks,
                     PackageReferences = nugetPackages.ToList(),
-                    ProjectReferences = analyzer.ProjectResult.ExternalReferences.ProjectReferences.Select(p => new ProjectReference { ReferencePath = p.AssemblyLocation }).ToList(),
+                    ProjectReferences = analyzer.ProjectResult.ExternalReferences.ProjectReferences.ConvertAll(p => new ProjectReference { ReferencePath = p.AssemblyLocation }),
                     PackageAnalysisResults = packageAnalysisResults,
                     IsBuildFailed = analyzer.ProjectResult.IsBuildFailed(),
                     Errors = analyzer.ProjectResult.BuildErrors,

--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -115,7 +115,7 @@ namespace PortingAssistant.Client.Analysis
 
                 var packageAnalysisResults = nugetPackages.Select(package =>
                 {
-                    var result = PackageCompatibility.isCompatibleAsync(packageResults.GetValueOrDefault(package, null), package, _logger);
+                    var result = PackageCompatibility.IsCompatibleAsync(packageResults.GetValueOrDefault(package, null), package, _logger);
                     var packageAnalysisResult = PackageCompatibility.GetPackageAnalysisResult(result, package);
                     return new Tuple<PackageVersionPair, Task<PackageAnalysisResult>>(package, packageAnalysisResult);
                 }).ToDictionary(t => t.Item1, t => t.Item2);

--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -62,8 +62,6 @@ namespace PortingAssistant.Client.Analysis
         {
             try
             {
-                var invocationsMethodSignatures = new HashSet<string>();
-
                 using var analyzer = analyzers.Find((a) => a.ProjectResult?.ProjectFilePath != null &&
                     a.ProjectResult.ProjectFilePath.Equals(project));
 
@@ -90,10 +88,6 @@ namespace PortingAssistant.Client.Analysis
 
                 var targetframeworks = analyzer.ProjectResult.TargetFrameworks.Count == 0 ?
                     new List<string> { analyzer.ProjectResult.TargetFramework } : analyzer.ProjectResult.TargetFrameworks;
-
-                var ProjectReferences = analyzer.ProjectResult.ExternalReferences.ProjectReferences.Count == 0 ?
-                    new List<string>() :
-                    analyzer.ProjectResult.ExternalReferences.ProjectReferences.Select(p => p.AssemblyLocation).ToList();
 
                 var nugetPackages = analyzer.ProjectResult.ExternalReferences.NugetReferences
                     .Select(r => InvocationExpressionModelToInvocations.ReferenceToPackageVersionPair(r))

--- a/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
@@ -46,7 +46,7 @@ namespace PortingAssistant.Client.Analysis.Utils
                 }
 
                 compatiblityResult.Compatibility = HasLesserTarget(version, targetFramework.ToArray()) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE;
-                compatiblityResult.CompatibleVersions = targetFramework.ToArray()
+                compatiblityResult.CompatibleVersions = targetFramework
                     .Where(v =>
                     {
                         if (!NuGetVersion.TryParse(v, out var semversion))
@@ -65,7 +65,7 @@ namespace PortingAssistant.Client.Analysis.Utils
             }
 
             compatiblityResult.Compatibility = HasLesserTarget(version, framework.ToArray()) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE;
-            compatiblityResult.CompatibleVersions = framework.ToArray()
+            compatiblityResult.CompatibleVersions = framework
                 .Where(v =>
                 {
                     if (!NuGetVersion.TryParse(v, out var semversion))

--- a/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
@@ -45,7 +45,7 @@ namespace PortingAssistant.Client.Analysis.Utils
                     return compatiblityResult;
                 }
 
-                compatiblityResult.Compatibility = hasLesserTarget(version, targetFramework.ToArray()) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE;
+                compatiblityResult.Compatibility = HasLesserTarget(version, targetFramework.ToArray()) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE;
                 compatiblityResult.CompatibleVersions = targetFramework.ToArray()
                     .Where(v =>
                     {
@@ -64,7 +64,7 @@ namespace PortingAssistant.Client.Analysis.Utils
                 return compatiblityResult;
             }
 
-            compatiblityResult.Compatibility = hasLesserTarget(version, framework.ToArray()) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE;
+            compatiblityResult.Compatibility = HasLesserTarget(version, framework.ToArray()) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE;
             compatiblityResult.CompatibleVersions = framework.ToArray()
                 .Where(v =>
                 {
@@ -77,7 +77,7 @@ namespace PortingAssistant.Client.Analysis.Utils
             return compatiblityResult;
         }
 
-        private static bool hasLesserTarget(string version, string[] targetVersions)
+        private static bool HasLesserTarget(string version, string[] targetVersions)
         {
             if (!NuGetVersion.TryParse(version, out var target))
             {
@@ -183,7 +183,7 @@ namespace PortingAssistant.Client.Analysis.Utils
                     entity.Value.Wait();
                     if (entity.Value.IsCompletedSuccessfully)
                     {
-                        var indexDict = signatureToIndexPreProcess(entity.Value.Result);
+                        var indexDict = SignatureToIndexPreProcess(entity.Value.Result);
                         return new Tuple<PackageVersionPair, PackageDetailsWithApiIndices>(entity.Key, new PackageDetailsWithApiIndices
                         {
                             PackageDetails = entity.Value.Result,
@@ -199,7 +199,7 @@ namespace PortingAssistant.Client.Analysis.Utils
             }).Where(p => p != null).ToDictionary(t => t.Item1, t => t.Item2);
         }
 
-        private static Dictionary<string, int> signatureToIndexPreProcess(PackageDetails packageDetails)
+        private static Dictionary<string, int> SignatureToIndexPreProcess(PackageDetails packageDetails)
         {
             var indexDict = new Dictionary<string, int>();
             if (packageDetails == null || packageDetails.Api == null)

--- a/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
@@ -105,7 +105,7 @@ namespace PortingAssistant.Client.Analysis.Utils
             try
             {
 
-                if (compatibilityResult != null && compatibilityResult.CompatibleVersions != null)
+                if (compatibilityResult?.CompatibleVersions != null)
                 {
                     var validVersions = compatibilityResult.CompatibleVersions.Where(v => !v.Contains("-")).ToList();
                     if (validVersions.Count != 0)
@@ -211,13 +211,13 @@ namespace PortingAssistant.Client.Analysis.Utils
             {
                 var api = packageDetails.Api[i];
                 var signature = api.MethodSignature.Replace("?", "");
-                if (signature != null && signature != "" && !indexDict.ContainsKey(signature))
+                if (!string.IsNullOrEmpty(signature) && !indexDict.ContainsKey(signature))
                 {
                     indexDict.Add(signature, i);
                 }
 
                 var extensionSignature = GetExtensionSignature(api);
-                if (extensionSignature != null && extensionSignature != "" && !indexDict.ContainsKey(extensionSignature))
+                if (!string.IsNullOrEmpty(extensionSignature) && !indexDict.ContainsKey(extensionSignature))
                 {
                     indexDict.Add(extensionSignature, i);
                 }

--- a/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
@@ -10,7 +10,6 @@ namespace PortingAssistant.Client.Analysis.Utils
     public static class ApiCompatiblity
     {
         public const string DEFAULT_TARGET = "netcoreapp3.1";
-        private static Dictionary<PackageDetails, Dictionary<string, int>> preIndexDict = new Dictionary<PackageDetails, Dictionary<string, int>>();
         private static readonly ApiRecommendation DEFAULT_RECOMMENDATION = new ApiRecommendation
         {
             RecommendedActionType = RecommendedActionType.NoRecommendation
@@ -101,7 +100,6 @@ namespace PortingAssistant.Client.Analysis.Utils
         public static ApiRecommendation UpgradeStrategy(
             CompatibilityResult compatibilityResult,
             string apiMethodSignature,
-            string nameSpaceToQuery,
             Task<RecommendationDetails> recommendationDetails)
         {
             try
@@ -119,7 +117,7 @@ namespace PortingAssistant.Client.Analysis.Utils
                         };
                     }
                 }
-                return FetchApiRecommendation(apiMethodSignature, nameSpaceToQuery, recommendationDetails);
+                return FetchApiRecommendation(apiMethodSignature, recommendationDetails);
             }
             catch
             {
@@ -130,7 +128,6 @@ namespace PortingAssistant.Client.Analysis.Utils
 
         private static ApiRecommendation FetchApiRecommendation(
             string apiMethodSignature,
-            string nameSpaceToQuery,
             Task<RecommendationDetails> recommendationDetails)
         {
             if (apiMethodSignature != null && recommendationDetails != null)

--- a/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/ApiCompatiblity.cs
@@ -166,7 +166,7 @@ namespace PortingAssistant.Client.Analysis.Utils
 
             var index = packageDetailsWithApiIndices.IndexDict.GetValueOrDefault(apiMethodSignature.Replace("?", ""), -1);
 
-            if (index >= 0 && index < packageDetailsWithApiIndices.PackageDetails.Api.Count())
+            if (index >= 0 && index < packageDetailsWithApiIndices.PackageDetails.Api.Length)
             {
                 return packageDetailsWithApiIndices.PackageDetails.Api[index];
             }
@@ -207,7 +207,7 @@ namespace PortingAssistant.Client.Analysis.Utils
                 return indexDict;
             }
 
-            for (int i = 0; i < packageDetails.Api.Count(); i++)
+            for (int i = 0; i < packageDetails.Api.Length; i++)
             {
                 var api = packageDetails.Api[i];
                 var signature = api.MethodSignature.Replace("?", "");
@@ -231,7 +231,7 @@ namespace PortingAssistant.Client.Analysis.Utils
         {
             try
             {
-                if (api == null || api.MethodParameters == null || api.MethodParameters.Count() == 0)
+                if (api == null || api.MethodParameters == null || api.MethodParameters.Length == 0)
                 {
                     return null;
                 }

--- a/src/PortingAssistant.Client.Analysis/Utils/InvocationExpressionModelToInvocations.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/InvocationExpressionModelToInvocations.cs
@@ -92,18 +92,18 @@ namespace PortingAssistant.Client.Analysis.Utils
 
                         // Check if invocation is from Nuget
                         var potentialNugetPackage = analyzer?.ProjectResult?.ExternalReferences?.NugetReferences?.Find((n) =>
-                           n.AssemblyLocation != null && n.AssemblyLocation.EndsWith(invocation.Reference.Assembly + ".dll")); 
-                        
+                           n.AssemblyLocation?.EndsWith(invocation.Reference.Assembly + ".dll") == true);
+
                         if (potentialNugetPackage == null)
                         {
                             potentialNugetPackage = analyzer?.ProjectResult?.ExternalReferences?.NugetDependencies?.Find((n) =>
-                           n.AssemblyLocation != null && n.AssemblyLocation.EndsWith(invocation.Reference.Assembly + ".dll"));
+                           n.AssemblyLocation?.EndsWith(invocation.Reference.Assembly + ".dll") == true);
                         }
                         PackageVersionPair nugetPackage = ReferenceToPackageVersionPair(potentialNugetPackage);
 
                         // Check if invocation is from SDK
                         var potentialSdk = analyzer?.ProjectResult?.ExternalReferences?.SdkReferences?.Find((s) =>
-                            s.AssemblyLocation != null && s.AssemblyLocation.EndsWith(invocation.Reference.Assembly + ".dll"));
+                            s.AssemblyLocation?.EndsWith(invocation.Reference.Assembly + ".dll") == true);
                         PackageVersionPair sdk = ReferenceToPackageVersionPair(potentialSdk, PackageSourceType.SDK);
 
                         // If both nuget package and sdk are null, this invocation is from an internal project. Skip it.

--- a/src/PortingAssistant.Client.Analysis/Utils/InvocationExpressionModelToInvocations.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/InvocationExpressionModelToInvocations.cs
@@ -48,7 +48,6 @@ namespace PortingAssistant.Client.Analysis.Utils
                         var apiRecommendation = ApiCompatiblity.UpgradeStrategy(
                                                 compatibilityResult,
                                                 invocation.OriginalDefinition,
-                                                invocation.Namespace,
                                                 recommendationDetails);
 
 

--- a/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
@@ -43,7 +43,7 @@ namespace PortingAssistant.Client.Analysis.Utils
             };
         }
 
-        public static async Task<CompatibilityResult> isCompatibleAsync(Task<PackageDetails> packageDetails, PackageVersionPair packageVersionPair, ILogger _logger, string target = DEFAULT_TARGET)
+        public static async Task<CompatibilityResult> IsCompatibleAsync(Task<PackageDetails> packageDetails, PackageVersionPair packageVersionPair, ILogger _logger, string target = DEFAULT_TARGET)
         {
             if (packageDetails == null || packageVersionPair == null)
             {

--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -12,13 +12,13 @@ namespace PortingAssistant.Client.Client
 {
     public class PortingAssistantClient : IPortingAssistantClient
     {
-        private readonly IPortingAssistantAnalysisHandler _AnalysisHandler;
+        private readonly IPortingAssistantAnalysisHandler _analysisHandler;
         private readonly IPortingHandler _portingHandler;
 
         public PortingAssistantClient(IPortingAssistantAnalysisHandler AnalysisHandler,
             IPortingHandler portingHandler)
         {
-            _AnalysisHandler = AnalysisHandler;
+            _analysisHandler = AnalysisHandler;
             _portingHandler = portingHandler;
         }
 
@@ -36,7 +36,7 @@ namespace PortingAssistant.Client.Client
                     .Select(p => p.AbsolutePath)
                     .ToList();
 
-                var projectAnalysisResultsDict = await _AnalysisHandler.AnalyzeSolution(solutionFilePath, projects);
+                var projectAnalysisResultsDict = await _analysisHandler.AnalyzeSolution(solutionFilePath, projects);
 
                 var projectAnalysisResults = projects.Select(p =>
                 {
@@ -56,7 +56,8 @@ namespace PortingAssistant.Client.Client
                 {
                     SolutionName = Path.GetFileNameWithoutExtension(solutionFilePath),
                     SolutionFilePath = solutionFilePath,
-                    Projects = projectAnalysisResults.ConvertAll(p => new ProjectDetails {
+                    Projects = projectAnalysisResults.ConvertAll(p => new ProjectDetails
+                    {
                         PackageReferences = p.PackageReferences,
                         ProjectFilePath = p.ProjectFilePath,
                         ProjectGuid = p.ProjectGuid,

--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -5,7 +5,6 @@ using PortingAssistant.Client.Analysis;
 using PortingAssistant.Client.Model;
 using PortingAssistant.Client.Porting;
 using Microsoft.Build.Construction;
-using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -13,16 +12,12 @@ namespace PortingAssistant.Client.Client
 {
     public class PortingAssistantClient : IPortingAssistantClient
     {
-        private readonly ILogger _logger;
         private readonly IPortingAssistantAnalysisHandler _AnalysisHandler;
         private readonly IPortingHandler _portingHandler;
 
-        public PortingAssistantClient(ILogger<PortingAssistantClient> logger,
-            IPortingAssistantAnalysisHandler AnalysisHandler,
-            IPortingHandler portingHandler
-            )
+        public PortingAssistantClient(IPortingAssistantAnalysisHandler AnalysisHandler,
+            IPortingHandler portingHandler)
         {
-            _logger = logger;
             _AnalysisHandler = AnalysisHandler;
             _portingHandler = portingHandler;
         }

--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -34,11 +34,10 @@ namespace PortingAssistant.Client.Client
                 var solution = SolutionFile.Parse(solutionFilePath);
                 var failedProjects = new List<string>();
 
-                var projects = solution.ProjectsInOrder.Where(p => 
-                    (p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat || 
-                    p.ProjectType == SolutionProjectType.WebProject) && 
-                    (settings.IgnoreProjects == null ||
-                    !settings.IgnoreProjects.Contains(p.AbsolutePath)))
+                var projects = solution.ProjectsInOrder.Where(p =>
+                    (p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat ||
+                    p.ProjectType == SolutionProjectType.WebProject) &&
+                    (settings.IgnoreProjects?.Contains(p.AbsolutePath) != true))
                     .Select(p => p.AbsolutePath)
                     .ToList();
 
@@ -62,7 +61,7 @@ namespace PortingAssistant.Client.Client
                 {
                     SolutionName = Path.GetFileNameWithoutExtension(solutionFilePath),
                     SolutionFilePath = solutionFilePath,
-                    Projects = projectAnalysisResults.Select(p => new ProjectDetails { 
+                    Projects = projectAnalysisResults.Select(p => new ProjectDetails {
                         PackageReferences = p.PackageReferences,
                         ProjectFilePath = p.ProjectFilePath,
                         ProjectGuid = p.ProjectGuid,

--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -61,7 +61,7 @@ namespace PortingAssistant.Client.Client
                 {
                     SolutionName = Path.GetFileNameWithoutExtension(solutionFilePath),
                     SolutionFilePath = solutionFilePath,
-                    Projects = projectAnalysisResults.Select(p => new ProjectDetails {
+                    Projects = projectAnalysisResults.ConvertAll(p => new ProjectDetails {
                         PackageReferences = p.PackageReferences,
                         ProjectFilePath = p.ProjectFilePath,
                         ProjectGuid = p.ProjectGuid,
@@ -70,7 +70,7 @@ namespace PortingAssistant.Client.Client
                         ProjectType = p.ProjectType,
                         TargetFrameworks = p.TargetFrameworks,
                         IsBuildFailed = p.IsBuildFailed
-                    }).ToList(),
+                    }),
 
                     FailedProjects = failedProjects
                 };

--- a/src/PortingAssistant.Client.Client/Reports/ReportExporter.cs
+++ b/src/PortingAssistant.Client.Client/Reports/ReportExporter.cs
@@ -104,7 +104,7 @@ namespace PortingAssistant.Client.Client.Reports
                     Task.WaitAll(writeToFiles.ToArray());
 
                 });
-                if (FailedProjects != null && FailedProjects.Count != 0)
+                if (FailedProjects?.Count != 0)
                 {
                     WriteReportToFileAsync(FailedProjects, Path.Combine(BaseDir, "failed.json")).Wait();
                 }

--- a/src/PortingAssistant.Client.Client/Reports/ReportExporter.cs
+++ b/src/PortingAssistant.Client.Client/Reports/ReportExporter.cs
@@ -122,13 +122,10 @@ namespace PortingAssistant.Client.Client.Reports
         {
             try
             {
-                using (var destinationStream = new FileStream(FilePath, FileMode.Create))
-                {
-                    using (var memoStream = new MemoryStream(obj.Serialize<T>()))
-                    {
-                        await memoStream.CopyToAsync(destinationStream);
-                    }
-                }
+                using var destinationStream = new FileStream(FilePath, FileMode.Create);
+                using var memoStream = new MemoryStream(obj.Serialize<T>());
+
+                await memoStream.CopyToAsync(destinationStream);
                 _logger.LogInformation("file generated at ", FilePath);
                 return true;
             }
@@ -152,18 +149,13 @@ namespace PortingAssistant.Client.Client.Reports
 
         public static byte[] Serialize<T>(this T data)
         {
-            using (var outputStream = new MemoryStream())
-            {
-                using (var writer = new StreamWriter(outputStream))
-                {
-                    using (var jsonWriter = new JsonTextWriter(writer))
-                    {
-                        Serializer.Serialize(jsonWriter, data);
-                    }
-                }
+            using var outputStream = new MemoryStream();
+            using var writer = new StreamWriter(outputStream);
+            using var jsonWriter = new JsonTextWriter(writer);
 
-                return outputStream.ToArray();
-            }
+            Serializer.Serialize(jsonWriter, data);
+
+            return outputStream.ToArray();
         }
 
         public static T Deserialize<T>(this Stream stream)

--- a/src/PortingAssistant.Client.Common/Model/PackageDetails.cs
+++ b/src/PortingAssistant.Client.Common/Model/PackageDetails.cs
@@ -43,7 +43,7 @@ namespace PortingAssistant.Client.Model
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(License); ;
+            return HashCode.Combine(License);
         }
     }
 

--- a/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
@@ -31,17 +31,17 @@ namespace PortingAssistant.Client.NuGet
             _httpService = httpService;
         }
 
-        public Dictionary<PackageVersionPair, Task<PackageDetails>> CheckAsync(
+        public Dictionary<PackageVersionPair, Task<PackageDetails>> Check(
             IEnumerable<PackageVersionPair> packageVersions,
             string pathToSolution)
         {
             var packagesToCheck = packageVersions;
 
-            if(CompatibilityCheckerType == PackageSourceType.SDK)
+            if (CompatibilityCheckerType == PackageSourceType.SDK)
             {
                 packagesToCheck = packageVersions.Where(package => package.PackageSourceType == PackageSourceType.SDK);
             }
-            
+
             var compatibilityTaskCompletionSources = packagesToCheck
                 .Select(packageVersion =>
                 {

--- a/src/PortingAssistant.Client.NuGet/Checkers/InternalPackagesCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/InternalPackagesCompatibilityChecker.cs
@@ -79,7 +79,7 @@ namespace PortingAssistant.Client.NuGet
 
                         versionSet.Add(version);
                         var compatibility = await ProcessCompatibility(packageVersionPair, internalRepositories);
-                        if (compatibility != null && compatibility.IsCompatible)
+                        if (compatibility?.IsCompatible == true)
                         {
                             compatibleVersionSet.Add(version);
                         }

--- a/src/PortingAssistant.Client.NuGet/Checkers/InternalPackagesCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/InternalPackagesCompatibilityChecker.cs
@@ -30,7 +30,7 @@ namespace PortingAssistant.Client.NuGet
             _logger = logger;
         }
 
-        public Dictionary<PackageVersionPair, Task<PackageDetails>> CheckAsync(
+        public Dictionary<PackageVersionPair, Task<PackageDetails>> Check(
             IEnumerable<PackageVersionPair> packageVersions,
             string pathToSolution)
         {

--- a/src/PortingAssistant.Client.NuGet/Checkers/InternalPackagesCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/InternalPackagesCompatibilityChecker.cs
@@ -152,9 +152,9 @@ namespace PortingAssistant.Client.NuGet
             var repositories = sourceRepositoryProvider
                 .GetRepositories()
                 .Where(r =>
-                    r.PackageSource.Name.ToLower() != "nuget.org"
+                    !string.Equals(r.PackageSource.Name, "nuget.org", StringComparison.OrdinalIgnoreCase)
                     && r.PackageSource.IsEnabled
-                    && r.PackageSource.Name.ToLower() != "microsoft visual studio offline packages")
+                    && !string.Equals(r.PackageSource.Name, "microsoft visual studio offline packages", StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             return repositories;

--- a/src/PortingAssistant.Client.NuGet/Checkers/PortabilityAnalyzerCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/PortabilityAnalyzerCompatibilityChecker.cs
@@ -152,7 +152,6 @@ namespace PortingAssistant.Client.NuGet
                 {
                     if (ex.Message.Contains("404"))
                     {
-                        var s3Exception = ex as AmazonS3Exception;
                         _logger.LogInformation($"Encountered {ex.GetType()} while downloading and parsing {url.Key} " +
                                               $"from {CompatibilityCheckerType}, but it was ignored. " +
                                               $"ErrorMessage: {ex.Message}.");

--- a/src/PortingAssistant.Client.NuGet/Checkers/PortabilityAnalyzerCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/PortabilityAnalyzerCompatibilityChecker.cs
@@ -49,7 +49,7 @@ namespace PortingAssistant.Client.NuGet
         /// <param name="packageVersions">The package versions to check</param>
         /// <param name="pathToSolution">Path to the solution to check</param>
         /// <returns>The results of the compatibility check</returns>
-        public Dictionary<PackageVersionPair, Task<PackageDetails>> CheckAsync(
+        public Dictionary<PackageVersionPair, Task<PackageDetails>> Check(
             IEnumerable<PackageVersionPair> packageVersions,
             string pathToSolution)
         {

--- a/src/PortingAssistant.Client.NuGet/Interfaces/ICompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Interfaces/ICompatibilityChecker.cs
@@ -21,6 +21,6 @@ namespace PortingAssistant.Client.NuGet
         /// <param name="packageVersions">A collection of packages and their versions</param>
         /// <param name="pathToSolution">The solution to check</param>
         /// <returns></returns>
-        public Dictionary<PackageVersionPair, Task<PackageDetails>> CheckAsync(IEnumerable<PackageVersionPair> packageVersions, string pathToSolution);
+        public Dictionary<PackageVersionPair, Task<PackageDetails>> Check(IEnumerable<PackageVersionPair> packageVersions, string pathToSolution);
     }
 }

--- a/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
+++ b/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
@@ -61,7 +61,7 @@ namespace PortingAssistant.Client.NuGet
             {
                 try
                 {
-                    var compatibilityResults = compatibilityChecker.CheckAsync(distinctPackageVersions, pathToSolution);
+                    var compatibilityResults = compatibilityChecker.Check(distinctPackageVersions, pathToSolution);
                     await Task.WhenAll(compatibilityResults.Select(result =>
                     {
                         return result.Value.ContinueWith(task =>

--- a/src/PortingAssistant.Client.Porting/PortingHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 using PortingAssistant.Client.Model;
 using PortingAssistant.Client.PortingProjectFile;
 
@@ -8,7 +7,6 @@ namespace PortingAssistant.Client.Porting
 {
     public class PortingHandler : IPortingHandler
     {
-        private readonly ILogger _logger;
         private readonly IPortingProjectFileHandler _portingProjectFileHandler;
 
         /// <summary>
@@ -16,9 +14,8 @@ namespace PortingAssistant.Client.Porting
         /// </summary>
         /// <param name="logger">An ILogger object</param>
         /// <param name="portingProjectFileHandler">A instance of a handler object to run the porting</param>
-        public PortingHandler(ILogger<PortingHandler> logger, IPortingProjectFileHandler portingProjectFileHandler)
+        public PortingHandler(IPortingProjectFileHandler portingProjectFileHandler)
         {
-            _logger = logger;
             _portingProjectFileHandler = portingProjectFileHandler;
         }
 

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
@@ -21,7 +21,7 @@ namespace PortingAssistant.Client.PortingProjectFile
         private readonly ILogger _logger;
         private readonly MigrationFacility _facility;
 
-        private static readonly ProjectWriteOptions writeOptions = new ProjectWriteOptions
+        private static readonly ProjectWriteOptions WriteOptions = new ProjectWriteOptions
         {
             MakeBackups = false
         };
@@ -71,7 +71,7 @@ namespace PortingAssistant.Client.PortingProjectFile
 
             var selectedProjects = projects.Where(project => projectPaths.Contains(project.FilePath.FullName)).ToList();
 
-            var writer = new ProjectWriter(_logger, writeOptions);
+            var writer = new ProjectWriter(_logger, WriteOptions);
 
             foreach (var project in selectedProjects)
             {

--- a/src/PortingAssistant.Client/PortingAssistantCLI.cs
+++ b/src/PortingAssistant.Client/PortingAssistantCLI.cs
@@ -66,7 +66,7 @@ namespace PortingAssistant.Client.CLI
                     }
                     SolutionPath = o.SolutionPath;
 
-                    if (o.OutputPath == null || o.OutputPath.Length == 0)
+                    if (string.IsNullOrEmpty(o.OutputPath))
                     {
                         Console.WriteLine("Invalid output path " + OutputPath);
                         Environment.Exit(-1);

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantAnalysisHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantAnalysisHandlerTest.cs
@@ -72,7 +72,7 @@ namespace PortingAssistant.Client.Tests
             _solutionFile = Path.Combine(TestContext.CurrentContext.TestDirectory,
                 "TestXml", "SolutionWithApi", "SolutionWithApi.sln");
             _projects = GetProjects(_solutionFile);
-            _projectPaths = _projects.Select(p => p.ProjectFilePath).ToList();
+            _projectPaths = _projects.ConvertAll(p => p.ProjectFilePath);
 
             _nuGetHandlerMock.Reset();
 

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantAnalysisHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantAnalysisHandlerTest.cs
@@ -110,8 +110,6 @@ namespace PortingAssistant.Client.Tests
                     return null;
                 }
 
-                var projectParser = new ProjectFileParser(p.AbsolutePath);
-
                 return new ProjectDetails
                 {
                     ProjectName = p.ProjectName,

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
@@ -113,8 +113,7 @@ namespace PortingAssistant.Client.Tests
         public void OneTimeSetUp()
         {
             _apiAnalysisHandlerMock = new Mock<IPortingAssistantAnalysisHandler>();
-            _portingHandlerMock = new PortingHandler(NullLogger<PortingHandler>.Instance, 
-                new PortingProjectFileHandler(NullLogger<PortingProjectFileHandler>.Instance));
+            _portingHandlerMock = new PortingHandler(new PortingProjectFileHandler(NullLogger<PortingProjectFileHandler>.Instance));
             _portingAssistantClient = new PortingAssistantClient(
                 NullLogger<PortingAssistantClient>.Instance,
                 _apiAnalysisHandlerMock.Object,

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
@@ -115,7 +115,6 @@ namespace PortingAssistant.Client.Tests
             _apiAnalysisHandlerMock = new Mock<IPortingAssistantAnalysisHandler>();
             _portingHandlerMock = new PortingHandler(new PortingProjectFileHandler(NullLogger<PortingProjectFileHandler>.Instance));
             _portingAssistantClient = new PortingAssistantClient(
-                NullLogger<PortingAssistantClient>.Instance,
                 _apiAnalysisHandlerMock.Object,
                 _portingHandlerMock);
         }

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
@@ -180,7 +180,7 @@ namespace PortingAssistant.Client.Tests
                                 _sourceFileAnalysisResult
                             },
                             ProjectGuid = "xxx",
-                            ProjectType = SolutionProjectType.KnownToBeMSBuildFormat.ToString()
+                            ProjectType = nameof(SolutionProjectType.KnownToBeMSBuildFormat)
                         };
 
                         return new KeyValuePair<string, ProjectAnalysisResult>(project, projectAnalysisResult);
@@ -206,11 +206,11 @@ namespace PortingAssistant.Client.Tests
                     ProjectName = p.ProjectName,
                     ProjectFilePath = p.AbsolutePath,
                     ProjectGuid = p.ProjectGuid,
-                    TargetFrameworks = projectParser.GetTargetFrameworks().Select(tfm =>
+                    TargetFrameworks = projectParser.GetTargetFrameworks().ConvertAll(tfm =>
                     {
                         var framework = NuGetFramework.Parse(tfm);
                         return string.Format("{0} {1}", framework.Framework, NuGetVersion.Parse(framework.Version.ToString()).ToNormalizedString());
-                    }).ToList(),
+                    }),
                     PackageReferences = projectParser.GetPackageReferences()
                 };
             }).Where(p => p != null).ToList();
@@ -237,7 +237,7 @@ namespace PortingAssistant.Client.Tests
 
             Task.WaitAll(packageAnalysisResult.Values.ToArray());
             var packageResult = packageAnalysisResult.First(p => p.Value.Result.PackageVersionPair.PackageId == _packageDetails.Name);
-            Assert.AreEqual(RecommendedActionType.UpgradePackage, packageResult.Value.Result.Recommendations.RecommendedActions.First().RecommendedActionType); ;
+            Assert.AreEqual(RecommendedActionType.UpgradePackage, packageResult.Value.Result.Recommendations.RecommendedActions.First().RecommendedActionType);
             var compatibilityResult = packageResult.Value.Result.CompatibilityResults.GetValueOrDefault(PackageCompatibility.DEFAULT_TARGET);
             Assert.AreEqual(Compatibility.COMPATIBLE, compatibilityResult.Compatibility);
             Assert.AreEqual("12.0.3", compatibilityResult.CompatibleVersions.First());
@@ -246,11 +246,11 @@ namespace PortingAssistant.Client.Tests
             Assert.AreEqual("SolutionWithProjects", solutionDetail.SolutionName);
 
             Assert.AreEqual(5, solutionDetail.Projects.Count);
-            Assert.Contains("PortingAssistantApi", solutionDetail.Projects.Select(result => result.ProjectName).ToList());
+            Assert.Contains("PortingAssistantApi", solutionDetail.Projects.ConvertAll(result => result.ProjectName));
 
             var project = solutionDetail.Projects.First(project => project.ProjectName.Equals("PortingAssistantApi"));
             Assert.AreEqual("xxx", project.ProjectGuid);
-            Assert.AreEqual(SolutionProjectType.KnownToBeMSBuildFormat.ToString(), project.ProjectType);
+            Assert.AreEqual(nameof(SolutionProjectType.KnownToBeMSBuildFormat), project.ProjectType);
         }
 
         [Test]
@@ -261,14 +261,14 @@ namespace PortingAssistant.Client.Tests
                 ProjectPaths = new List<string> { _tmpProjectPath },
                 SolutionPath = _tmpSolutionDirectory,
                 TargetFramework = "netcoreapp3.1.0",
-                RecommendedActions = new List<RecommendedAction> 
+                RecommendedActions = new List<RecommendedAction>
                 {
                     new PackageRecommendation
                     {
                         PackageId = "Newtonsoft.Json",
                         RecommendedActionType = RecommendedActionType.UpgradePackage,
                         TargetVersions = new List<string> { "12.0.3" },
-                    } 
+                    }
                 }
             };
 

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantInternalNuGetCompatibilityHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantInternalNuGetCompatibilityHandlerTest.cs
@@ -28,7 +28,7 @@ namespace PortingAssistant.Client.Tests
 
             var repositories = sourceRepositoryProvider
                 .GetRepositories()
-                .Where(r => r.PackageSource.Name.ToLower() != "nuget.org");
+                .Where(r => !string.Equals(r.PackageSource.Name, "nuget.org", StringComparison.OrdinalIgnoreCase));
 
             return repositories;
         }

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -314,7 +314,7 @@ namespace PortingAssistant.Client.Tests
         private IPortingAssistantNuGetHandler GetCheckerWithException()
         {
             var checker = new Mock<ICompatibilityChecker>();
-            checker.Setup(checker => checker.CheckAsync(
+            checker.Setup(checker => checker.Check(
                 It.IsAny<List<PackageVersionPair>>(),
                 It.IsAny<string>()))
                 .Throws(new Exception("test"));
@@ -643,7 +643,7 @@ namespace PortingAssistant.Client.Tests
             };
             Assert.Throws<AggregateException>(() =>
             {
-                var resultTasks = externalChecker.CheckAsync(packages, null);
+                var resultTasks = externalChecker.Check(packages, null);
                 Task.WaitAll(resultTasks.Values.ToArray());
             });
         }
@@ -661,7 +661,7 @@ namespace PortingAssistant.Client.Tests
                 packageVersionPair
             };
 
-            var resultTasks = externalPackagesCompatibilityChecker.CheckAsync(packages, null);
+            var resultTasks = externalPackagesCompatibilityChecker.Check(packages, null);
 
             _loggerMock.Verify(_ => _.Log(
                 LogLevel.Error,
@@ -752,7 +752,7 @@ namespace PortingAssistant.Client.Tests
             {
                 packageVersionPair
             };
-            var result = _internalPackagesCompatibilityChecker.Object.CheckAsync(packages, Path.Combine(_testSolutionDirectory, "SolutionWithNugetConfigFile.sln"));
+            var result = _internalPackagesCompatibilityChecker.Object.Check(packages, Path.Combine(_testSolutionDirectory, "SolutionWithNugetConfigFile.sln"));
 
             Task.WaitAll(result.Values.ToArray());
             Assert.AreEqual(0, result.Values.ToList().First().Result.Targets.GetValueOrDefault("netcoreapp3.1").Count);
@@ -766,7 +766,7 @@ namespace PortingAssistant.Client.Tests
                 It.IsAny<IEnumerable<SourceRepository>>()))
                 .Throws(new AggregateException());
 
-            result = _internalPackagesCompatibilityChecker.Object.CheckAsync(packages, Path.Combine(_testSolutionDirectory, "SolutionWithNugetConfigFile.sln"));
+            result = _internalPackagesCompatibilityChecker.Object.Check(packages, Path.Combine(_testSolutionDirectory, "SolutionWithNugetConfigFile.sln"));
 
             Task.WaitAll(result.Values.ToArray());
             Assert.AreEqual(0, result.Values.First().Result.Targets.GetValueOrDefault("netcoreapp3.1").Count);

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -396,9 +396,9 @@ namespace PortingAssistant.Client.Tests
             Task.WaitAll(resultTasks.Values.ToArray());
 
             Assert.AreEqual(_packageDetails.Name, resultTasks.Values.First().Result.Name);
-            Assert.AreEqual(_packageDetails.Api.Count(), resultTasks.Values.First().Result.Api.Count());
-            Assert.AreEqual(_packageDetails.Targets.Count(), resultTasks.Values.First().Result.Targets.Count());
-            Assert.AreEqual(_packageDetails.Versions.Count(), resultTasks.Values.First().Result.Versions.Count());
+            Assert.AreEqual(_packageDetails.Api.Length, resultTasks.Values.First().Result.Api.Length);
+            Assert.AreEqual(_packageDetails.Targets.Count, resultTasks.Values.First().Result.Targets.Count);
+            Assert.AreEqual(_packageDetails.Versions.Count, resultTasks.Values.First().Result.Versions.Count);
         }
 
         [Test]
@@ -413,9 +413,9 @@ namespace PortingAssistant.Client.Tests
             Task.WaitAll(resultTasks.Values.ToArray());
 
             Assert.AreEqual(_packageDetails.Name, resultTasks.Values.First().Result.Name);
-            Assert.AreEqual(_packageDetails.Api.Count(), resultTasks.Values.First().Result.Api.Count());
-            Assert.AreEqual(_packageDetails.Targets.Count(), resultTasks.Values.First().Result.Targets.Count());
-            Assert.AreEqual(_packageDetails.Versions.Count(), resultTasks.Values.First().Result.Versions.Count());
+            Assert.AreEqual(_packageDetails.Api.Length, resultTasks.Values.First().Result.Api.Length);
+            Assert.AreEqual(_packageDetails.Targets.Count, resultTasks.Values.First().Result.Targets.Count);
+            Assert.AreEqual(_packageDetails.Versions.Count, resultTasks.Values.First().Result.Versions.Count);
         }
 
         [Test]
@@ -430,9 +430,9 @@ namespace PortingAssistant.Client.Tests
             Task.WaitAll(resultTasks.Values.ToArray());
 
             Assert.AreEqual(_packageDetails.Name, resultTasks.Values.First().Result.Name);
-            Assert.AreEqual(_packageDetails.Api.Count(), resultTasks.Values.First().Result.Api.Count());
-            Assert.AreEqual(_packageDetails.Targets.Count(), resultTasks.Values.First().Result.Targets.Count());
-            Assert.AreEqual(_packageDetails.Versions.Count(), resultTasks.Values.First().Result.Versions.Count());
+            Assert.AreEqual(_packageDetails.Api.Length, resultTasks.Values.First().Result.Api.Length);
+            Assert.AreEqual(_packageDetails.Targets.Count, resultTasks.Values.First().Result.Targets.Count);
+            Assert.AreEqual(_packageDetails.Versions.Count, resultTasks.Values.First().Result.Versions.Count);
         }
 
         [Test]
@@ -476,9 +476,9 @@ namespace PortingAssistant.Client.Tests
             Task.WaitAll(resultTasks.Values.ToArray());
 
             Assert.AreEqual(_packageDetails.Name, resultTasks.Values.First().Result.Name);
-            Assert.AreEqual(_packageDetails.Api.Count(), resultTasks.Values.First().Result.Api.Count());
-            Assert.AreEqual(_packageDetails.Targets.Count(), resultTasks.Values.First().Result.Targets.Count());
-            Assert.AreEqual(_packageDetails.Versions.Count(), resultTasks.Values.First().Result.Versions.Count());
+            Assert.AreEqual(_packageDetails.Api.Length, resultTasks.Values.First().Result.Api.Length);
+            Assert.AreEqual(_packageDetails.Targets.Count, resultTasks.Values.First().Result.Targets.Count);
+            Assert.AreEqual(_packageDetails.Versions.Count, resultTasks.Values.First().Result.Versions.Count);
         }
 
         [Test]

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -755,7 +755,7 @@ namespace PortingAssistant.Client.Tests
             var result = _internalPackagesCompatibilityChecker.Object.Check(packages, Path.Combine(_testSolutionDirectory, "SolutionWithNugetConfigFile.sln"));
 
             Task.WaitAll(result.Values.ToArray());
-            Assert.AreEqual(0, result.Values.ToList().First().Result.Targets.GetValueOrDefault("netcoreapp3.1").Count);
+            Assert.AreEqual(0, result.Values.First().Result.Targets.GetValueOrDefault("netcoreapp3.1").Count);
 
             _internalNuGetCompatibilityHandlerMock.Reset();
             _internalNuGetCompatibilityHandlerMock

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantPortingTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantPortingTest.cs
@@ -86,11 +86,11 @@ namespace PortingAssistant.Client.Tests
                     ProjectName = p.ProjectName,
                     ProjectFilePath = p.AbsolutePath,
                     ProjectGuid = p.ProjectGuid,
-                    TargetFrameworks = projectParser.GetTargetFrameworks().Select(tfm =>
+                    TargetFrameworks = projectParser.GetTargetFrameworks().ConvertAll(tfm =>
                     {
                         var framework = NuGetFramework.Parse(tfm);
                         return string.Format("{0} {1}", framework.Framework, NuGetVersion.Parse(framework.Version.ToString()).ToNormalizedString());
-                    }).ToList(),
+                    }),
                     PackageReferences = projectParser.GetPackageReferences()
                 };
             }).Where(p => p != null).ToList();

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantPortingTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantPortingTest.cs
@@ -25,7 +25,7 @@ namespace PortingAssistant.Client.Tests
         public void Setup()
         {
             _portingProjectFileHandler = new PortingProjectFileHandler(NullLogger<PortingProjectFileHandler>.Instance);
-            _portingHandler = new PortingHandler(NullLogger<PortingHandler>.Instance, _portingProjectFileHandler);
+            _portingHandler = new PortingHandler(_portingProjectFileHandler);
 
             var solutionDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestXml", "TestPorting");
             _tmpDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestXml", "TmpDirectory");

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantRecommendationTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantRecommendationTest.cs
@@ -40,7 +40,7 @@ namespace PortingAssistant.Client.UnitTests
                                 "netcore31"
                             },
                             Description = "System.Web (AKA classic ASP.NET) won't be ported to .NET Core. See https://aka.ms/unsupported-netfx-api.",
-                            Actions = new Actions[0]
+                            Actions = Array.Empty<Actions>()
                         }
                     }
                 }
@@ -86,7 +86,7 @@ namespace PortingAssistant.Client.UnitTests
                     return outputStream;
                 });
 
-            
+
 
             _portingAssistantRecommendationHandler = new PortingAssistantRecommendationHandler(
                 _httpService.Object,
@@ -106,8 +106,8 @@ namespace PortingAssistant.Client.UnitTests
             Assert.AreEqual(_recommendationDetails.Name, resultTasks.Values.First().Result.Name);
             Assert.AreEqual(_recommendationDetails.Version, resultTasks.Values.First().Result.Version);
             Assert.AreEqual(
-                _recommendationDetails.Recommendations.Count(),
-                resultTasks.Values.First().Result.Recommendations.Count());
+                _recommendationDetails.Recommendations.Length,
+                resultTasks.Values.First().Result.Recommendations.Length);
             Assert.AreEqual(
                 _recommendationDetails.Recommendations.First().Value,
                 resultTasks.Values.First().Result.Recommendations.First().Value);

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantResultsToInvocationsWithCompatibilityTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantResultsToInvocationsWithCompatibilityTest.cs
@@ -127,7 +127,7 @@ namespace PortingAssistant.Client.Tests
             Assert.AreEqual(1, result.First().ApiAnalysisResults.Count);
             Assert.AreEqual("11.0.1", result.First().ApiAnalysisResults.First().CodeEntityDetails.Package.Version);
             Assert.AreEqual(Compatibility.COMPATIBLE, result.First().ApiAnalysisResults.First().CompatibilityResults.GetValueOrDefault(ApiCompatiblity.DEFAULT_TARGET).Compatibility);
-            Assert.AreEqual("12.0.3", result[0].ApiAnalysisResults[0].Recommendations.RecommendedActions.First().Description); ;
+            Assert.AreEqual("12.0.3", result[0].ApiAnalysisResults[0].Recommendations.RecommendedActions.First().Description);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace PortingAssistant.Client.Tests
             Assert.AreEqual(1, result.First().ApiAnalysisResults.Count);
             Assert.AreEqual("11.0.1", result.First().ApiAnalysisResults.First().CodeEntityDetails.Package.Version);
             Assert.AreEqual(Compatibility.UNKNOWN, result.First().ApiAnalysisResults.First().CompatibilityResults.GetValueOrDefault(ApiCompatiblity.DEFAULT_TARGET).Compatibility);
-            Assert.IsNull(result[0].ApiAnalysisResults[0].Recommendations.RecommendedActions.First().Description); ;
+            Assert.IsNull(result[0].ApiAnalysisResults[0].Recommendations.RecommendedActions.First().Description);
         }
 
 

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantResultsToInvocationsWithCompatibilityTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantResultsToInvocationsWithCompatibilityTest.cs
@@ -121,17 +121,6 @@ namespace PortingAssistant.Client.Tests
                 }
             };
 
-            var project = new ProjectDetails
-            {
-                PackageReferences = new List<PackageVersionPair>
-                {
-                    new PackageVersionPair {
-                        PackageId = "namespace",
-                        Version = "11.2"
-                    }
-                }
-            };
-
             var result = InvocationExpressionModelToInvocations.AnalyzeResults(
                 sourceFileToInvocations, packageResults, recommendationResults);
 
@@ -150,17 +139,6 @@ namespace PortingAssistant.Client.Tests
                     "file1", new List<CodeEntityDetails>
                     {
                        _codeEntityDetails
-                    }
-                }
-            };
-
-            var project = new ProjectDetails
-            {
-                PackageReferences = new List<PackageVersionPair>
-                {
-                    new PackageVersionPair {
-                        PackageId = "namespace",
-                        Version = "11.2"
                     }
                 }
             };


### PR DESCRIPTION
* Rename methods to follow standards (https://github.com/aws/porting-assistant-dotnet-client/commit/1578991321345afef4bbb7b86bfef4663337fbda, https://github.com/aws/porting-assistant-dotnet-client/commit/4319cebf4ce4da2612ee0386234b402e60f20224).
* Optimize LINQ expressions (178f6e3, c3fb067).
* Remove unused code (147f876, 8219695, f0305b7, 5ce2865).
* Use conditional access and built-in string methods (ff78c96, 9fab849).
* Simplify nested using statements (1513dcc).

Feel free to revert any undesired change/commit.