### PR TITLE
fix spelling error for CLI option: output-path

### DIFF
--- a/src/PortingAssistant.Client/PortingAssistantCLI.cs
+++ b/src/PortingAssistant.Client/PortingAssistantCLI.cs
@@ -19,7 +19,7 @@ namespace PortingAssistant.Client.CLI
 
         public string PortingProjectPath { get; set; }
 
-        [Option('o', "ouput-path", Required = true, HelpText = "output folder.")]
+        [Option('o', "output-path", Required = true, HelpText = "output folder.")]
         public string OutputPath { get; set; }
 
         [Option('i', "ignore-projects", Separator = ',', Required = false, HelpText = "ignore projects in the solution")]


### PR DESCRIPTION
#### Description of change
Spelling error on the CLI option: output-path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
