### PR TITLE
Hanlde OOM exception and log memory consumptions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ commit-hook-tests/
 .idea/
 
 dist/
+**/launchSettings.json

--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -138,6 +138,7 @@ namespace PortingAssistant.Client.Analysis
         {
             try
             {
+                MemoryUtils.LogSolutiontSize(_logger, solutionFilename);
                 var configuration = GetAnalyzerConfiguration();
                 var analyzer = CodeAnalyzerFactory.GetAnalyzer(configuration, _logger);
                 var analyzersTask = await analyzer.AnalyzeSolution(solutionFilename);
@@ -234,6 +235,7 @@ namespace PortingAssistant.Client.Analysis
         {
             try
             {
+                MemoryUtils.LogSolutiontSize(_logger, solutionFilename);
                 var configuration = GetAnalyzerConfiguration();
                 var analyzer = CodeAnalyzerFactory.GetAnalyzer(configuration, _logger);
                 var analyzersTask = await analyzer.AnalyzeSolution(solutionFilename);

--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -9,6 +9,7 @@ using Codelyzer.Analysis;
 using Codelyzer.Analysis.Common;
 using Codelyzer.Analysis.Model;
 using Microsoft.Extensions.Logging;
+using PortingAssistant.Client.Common.Utils;
 using PortingAssistant.Client.Analysis.Utils;
 using PortingAssistant.Client.Model;
 using PortingAssistant.Client.NuGet;
@@ -160,6 +161,12 @@ namespace PortingAssistant.Client.Analysis
 
                 return solutionAnalysisResult;
             }
+            catch (OutOfMemoryException e)
+            {
+                _logger.LogError("Analyze solution {0} with error {1}", solutionFilename, e);
+                MemoryUtils.LogMemoryConsumption(_logger);
+                throw e;
+            }
             finally
             {
                 CommonUtils.RunGarbageCollection(_logger, "PortingAssistantAnalysisHandler.AnalyzeSolutionIncremental");
@@ -237,6 +244,12 @@ namespace PortingAssistant.Client.Analysis
                         .Select((project) => new KeyValuePair<string, ProjectAnalysisResult>(project, AnalyzeProject(project, solutionFilename, analyzersTask, analysisActions, isIncremental: false, targetFramework)))
                         .Where(p => p.Value != null)
                         .ToDictionary(p => p.Key, p => p.Value);
+            }
+            catch (OutOfMemoryException e)
+            {
+                _logger.LogError("Analyze solution {0} with error {1}", solutionFilename, e);
+                MemoryUtils.LogMemoryConsumption(_logger);
+                throw e;
             }
             finally
             {

--- a/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using PortingAssistant.Client.Common.Utils;
 using PortingAssistant.Client.Model;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
@@ -105,6 +106,16 @@ namespace PortingAssistant.Client.Analysis.Utils
                         return version.CompareTo(semversion) >= 0;
                     }) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE,
                     CompatibleVersions = compatibleVersions
+                };
+            }
+            catch (OutOfMemoryException e)
+            {
+                _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);
+                MemoryUtils.LogMemoryConsumption(_logger);
+                return new CompatibilityResult
+                {
+                    Compatibility = Compatibility.UNKNOWN,
+                    CompatibleVersions = new List<string>()
                 };
             }
             catch (Exception e)

--- a/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
+++ b/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+
+namespace PortingAssistant.Client.Common.Utils
+{
+    public static class MemoryUtils
+    {
+        public static void LogMemoryConsumption(ILogger logger)
+        {
+            // Determine the best available approximation of the number
+            // of bytes currently allocated in managed memory.
+            logger.LogInformation("Total Memory thought to be allocated in bytes: {0}", GC.GetTotalMemory(false));
+
+            // Gets the amount of private memory, in bytes, allocated for the associated process.
+            Process currentProc = Process.GetCurrentProcess();
+            logger.LogInformation("Total Memory allocated for current process in bytes: {0}", currentProc.PrivateMemorySize64);
+
+        }
+    }
+}

--- a/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
+++ b/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
@@ -1,21 +1,49 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
 
 namespace PortingAssistant.Client.Common.Utils
 {
     public static class MemoryUtils
     {
+        //
+        // Summary:
+        //     This method takes a logger and logs the number that is the
+        //     best available approximation of the number of bytes currently
+        //     allocated in managed memory. It also logs the total amount
+        //     of memory, in bytes, allocated for the associated process.
         public static void LogMemoryConsumption(ILogger logger)
         {
             // Determine the best available approximation of the number
             // of bytes currently allocated in managed memory.
-            logger.LogInformation("Total Memory thought to be allocated in bytes: {0}", GC.GetTotalMemory(false));
+            logger.LogInformation(
+                "Total Memory thought to be allocated in bytes: {0}",
+                GC.GetTotalMemory(false));
 
             // Gets the amount of private memory, in bytes, allocated for the associated process.
             Process currentProc = Process.GetCurrentProcess();
-            logger.LogInformation("Total Memory allocated for current process in bytes: {0}", currentProc.PrivateMemorySize64);
+            logger.LogInformation(
+                "Total Memory allocated for current process in bytes: {0}",
+                currentProc.PrivateMemorySize64);
 
+        }
+
+        //
+        // Summary:
+        //     This method takes a logger, path to a solution file, and logs
+        //     the total size of the solution, in bytes, by suming up the
+        //     size of each cs file contained in the solution.
+        public static void LogSolutiontSize(ILogger logger, string SolutionPath)
+        {
+            DirectoryInfo solutionDir = Directory.GetParent(SolutionPath);
+            var size = solutionDir.EnumerateFiles(
+                "*.cs", SearchOption.AllDirectories).Sum(fi => fi.Length);
+            logger.LogInformation(
+                "Total size for {} in bytes: {0}",
+                SolutionPath, size);
         }
     }
 }

--- a/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
+++ b/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
@@ -42,7 +42,7 @@ namespace PortingAssistant.Client.Common.Utils
             var size = solutionDir.EnumerateFiles(
                 "*.cs", SearchOption.AllDirectories).Sum(fi => fi.Length);
             logger.LogInformation(
-                "Total size for {} in bytes: {0}",
+                "Total size for {0} in bytes: {1}",
                 SolutionPath, size);
         }
     }

--- a/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using System.IO;
+using PortingAssistant.Client.Common.Utils;
 using PortingAssistant.Client.Model;
 using PortingAssistant.Client.NuGet.Interfaces;
 using PortingAssistant.Client.NuGet.Utils;
@@ -130,6 +131,11 @@ namespace PortingAssistant.Client.NuGet
                             packageVersionsFound.Add(packageVersion);
                         }
                     }
+                }
+                catch (OutOfMemoryException ex)
+                {
+                    _logger.LogError("Failed when downloading and parsing {0} from {1}, {2}", fileToDownload, CompatibilityCheckerType, ex);
+                    MemoryUtils.LogMemoryConsumption(_logger);
                 }
                 catch (Exception ex)
                 {

--- a/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
@@ -135,6 +135,7 @@ namespace PortingAssistant.Client.NuGet
                 catch (OutOfMemoryException ex)
                 {
                     _logger.LogError("Failed when downloading and parsing {0} from {1}, {2}", fileToDownload, CompatibilityCheckerType, ex);
+                    MemoryUtils.LogSolutiontSize(_logger, pathToSolution);
                     MemoryUtils.LogMemoryConsumption(_logger);
                 }
                 catch (Exception ex)

--- a/tests/PortingAssistant.Client.UnitTests/MemoryUtilsTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/MemoryUtilsTest.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using PortingAssistant.Client.Common.Utils;
+
+namespace PortingAssistant.Client.UnitTests
+{
+    class MemoryUtilsTest
+    {
+        private string testDirectoryRoot;
+        private string tmpTestFixturePath;
+        private ILogger testLogger;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            testDirectoryRoot = TestContext.CurrentContext.TestDirectory;
+            tmpTestFixturePath = Path.GetFullPath(Path.Combine(
+                Path.GetTempPath(),
+                Path.GetRandomFileName()));
+            Directory.CreateDirectory(tmpTestFixturePath);
+
+            // Extract test solution at tmpTestFixturePath
+            string testProjectZipPath = Path.Combine(
+                testDirectoryRoot,
+                "TestProjects",
+                "mvcmusicstore.zip");
+            using (ZipArchive archive = ZipFile.Open(
+                testProjectZipPath, ZipArchiveMode.Read))
+            {
+                archive.ExtractToDirectory(tmpTestFixturePath);
+            }
+
+            var serviceProvider = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+
+            var factory = serviceProvider.GetService<ILoggerFactory>();
+
+            testLogger = factory.CreateLogger("TestLogger");
+            testLogger.LogInformation("Total logs");
+        }
+
+        [Test]
+        public void TestLogSolutiontSize()
+        {
+            var testSolutionPath = Path.Combine(
+                tmpTestFixturePath, "mvcmusicstore", "MvcMusicStore.sln");
+            DirectoryInfo solutionDir = Directory.GetParent(testSolutionPath);
+            var totalFileCount = solutionDir.EnumerateFiles(
+                "*", SearchOption.AllDirectories).Count();
+            Assert.AreEqual(totalFileCount, 299);
+            var csFileCount = solutionDir.EnumerateFiles(
+                "*.cs", SearchOption.AllDirectories).Count();
+            Assert.AreEqual(csFileCount, 41);
+
+            // Run explicit GC
+            GC.Collect();
+
+            for (int i = 0; i <= 10; i++)
+            {
+                // Before the execution
+                long kbBeforeExecution = GC.GetTotalMemory(false) / 1024;
+
+                var watch = Stopwatch.StartNew();
+                MemoryUtils.LogSolutiontSize(testLogger, testSolutionPath);
+                watch.Stop();
+                var elapsedMs = watch.ElapsedMilliseconds;
+
+                long kbAfterExecution = GC.GetTotalMemory(false) / 1024;
+                // This will force garbage collection
+                long kbAfterGC = GC.GetTotalMemory(true) / 1024;
+
+                Console.WriteLine("----------Iteration " + i + "----------");
+                Console.WriteLine(elapsedMs + "ms to run LogSolutiontSize");
+                Console.WriteLine(kbBeforeExecution + "kb before LogSolutionSize.");
+                Console.WriteLine(kbAfterExecution + "kb after LogSolutionSize.");
+                Console.WriteLine(kbAfterGC + "kb after Garbage Collection");
+                Console.WriteLine(kbAfterExecution - kbBeforeExecution + "kb allocated during LogSolutionSize.");
+                Console.WriteLine(kbAfterExecution - kbAfterGC + "kb got collected by GC.");
+
+                // Verify All the short-lived objects in LogSolutiontSize are gabage collected
+                Assert.GreaterOrEqual(kbBeforeExecution - kbAfterGC, 0);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            Directory.Delete(tmpTestFixturePath, true);
+        }
+    }
+}

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistant.Client.UnitTests.csproj
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistant.Client.UnitTests.csproj
@@ -46,4 +46,13 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="TestProjects\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TestProjects\mvcmusicstore.zip">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
#### Description of change
[//]: # (What are you trying to fix? What did you change)
We've seen OutOfMemory exception being thrown few times from PA logs. This patch is to catch the exception and log the memory consumption.

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
