### PR TITLE
Check file write access before porting projects

### DIFF
--- a/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
+++ b/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
@@ -3,10 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-	
-  <ItemGroup>
-	<Folder Include="Utils\" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CTA.Rules.PortCore" Version="1.7.22-alpha-ga9389cf2cf" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
+++ b/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-
+	
   <ItemGroup>
-    <Folder Include="Utils\" />
+	<Folder Include="Utils\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CTA.Rules.PortCore" Version="1.7.22-alpha-ga9389cf2cf" />
@@ -13,6 +13,7 @@
     <PackageReference Include="NuGet.Protocol" Version="5.9.1" />
     <PackageReference Include="semver" Version="2.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />

--- a/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
+++ b/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="NuGet.Protocol" Version="5.9.1" />
     <PackageReference Include="semver" Version="2.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />

--- a/src/PortingAssistant.Client.Common/Utils/FileSystem.cs
+++ b/src/PortingAssistant.Client.Common/Utils/FileSystem.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Security.Principal;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using PortingAssistant.Client.Model;
+
+namespace PortingAssistant.Client.Common.Utils
+{
+    public static class FileSystem
+    {
+        /// <summary>
+        /// Checks solution and project folders to make sure we have write access
+        /// </summary>
+        /// <param name="projectPaths">List of project file paths</param>
+        /// <param name="solutionPath">Solution file path</param>
+        /// <returns>
+        /// (ProjectsWithoutAccess, ProjectsWithAccess)
+        /// If solution folder has no access, treats all projects as if no write access
+        /// </returns>
+        public static (List<string>, List<string>) VerifyFileAccess(List<string> projectPaths, string solutionPath)
+        {
+            var projectsWithoutAccess = new List<string>();
+            var projectsWithAccess = new List<string>();
+
+            // Check Solution Path
+            if (!HaveDirectoryWriteAccess(Path.GetDirectoryName(solutionPath)))
+            {
+                return (projectPaths, projectsWithAccess);
+            }
+            // Check Projects
+            foreach (string project in projectPaths)
+            {
+                string projectFolderPath = Path.GetDirectoryName(project);
+                // assuming that a project doesn't exist in the root directory so won't be null
+                if (CheckWriteAccessForDirectory(projectFolderPath))
+                {
+                    projectsWithAccess.Add(project);
+                }
+                else
+                {
+                    projectsWithoutAccess.Add(project);
+                }
+            }
+            return (projectsWithoutAccess, projectsWithAccess);
+        }
+
+        /// <summary>
+        /// Checks directory and all content for write access
+        /// </summary>
+        /// <param name="path">Directory path</param>
+        /// <returns>First file/directory with no write access found if any, blank if all contents have access</returns>
+        public static string CheckWriteAccessForDirectory(string path)
+        {
+            foreach (string file in Directory.GetFiles(path))
+            {
+                if (!HaveFileWriteAccess(file))
+                {
+                    Console.WriteLine($"File {file} does not have write access");
+                    return file;
+                }
+            }
+            foreach (string subDirectory in Directory.GetDirectories(path))
+            {
+                if (!HaveDirectoryWriteAccess(subDirectory))
+                {
+                    Console.WriteLine($"Directory {subDirectory} does not have write access");
+                    return subDirectory;
+                }
+                string result = CheckWriteAccessForDirectory(subDirectory);
+                if (result != string.Empty)
+                {
+                    return result;
+                }
+            }
+            return "";
+        }
+
+        private static bool HaveFileWriteAccess(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            FileSecurity accessControl = fileInfo.GetAccessControl();
+            AuthorizationRuleCollection rules = accessControl.GetAccessRules(true, true, typeof(SecurityIdentifier));
+            return CheckAuthorizationRules(rules);
+        }
+
+        private static bool HaveDirectoryWriteAccess(string path)
+        {
+            var directoryInfo = new DirectoryInfo(path);
+            DirectorySecurity accessControl = directoryInfo.GetAccessControl();
+            AuthorizationRuleCollection rules = accessControl.GetAccessRules(true, true, typeof(SecurityIdentifier));
+            return CheckAuthorizationRules(rules);
+        }
+
+        // Checks rules for write permission
+        private static bool CheckAuthorizationRules(AuthorizationRuleCollection rules)
+        {
+            bool hasAllowWrite = false;
+            bool hasDenyWrite = false;
+
+            var identity = WindowsIdentity.GetCurrent();
+
+            foreach (AuthorizationRule rule in rules)
+            {
+                if (identity.User.Equals(rule.IdentityReference) || identity.Groups.Contains(rule.IdentityReference))
+                {
+                    var filesystemAccessRule = (FileSystemAccessRule)rule;
+                    if ((filesystemAccessRule.FileSystemRights & FileSystemRights.Write) > 0 && filesystemAccessRule.AccessControlType != AccessControlType.Deny)
+                    {
+                        hasAllowWrite = true;
+                    }
+                    else if ((filesystemAccessRule.FileSystemRights & FileSystemRights.Write) > 0 && filesystemAccessRule.AccessControlType == AccessControlType.Deny)
+                    {
+                        hasDenyWrite = true;
+                    }
+                }
+            }
+            return hasAllowWrite && !hasDenyWrite;
+        }
+    }
+}

--- a/src/PortingAssistant.Client.Common/Utils/FileSystem.cs
+++ b/src/PortingAssistant.Client.Common/Utils/FileSystem.cs
@@ -11,42 +11,6 @@ namespace PortingAssistant.Client.Common.Utils
     public static class FileSystem
     {
         /// <summary>
-        /// Checks solution and project folders to make sure we have write access
-        /// </summary>
-        /// <param name="projectPaths">List of project file paths</param>
-        /// <param name="solutionPath">Solution file path</param>
-        /// <returns>
-        /// (ProjectsWithoutAccess, ProjectsWithAccess)
-        /// If solution folder has no access, treats all projects as if no write access
-        /// </returns>
-        public static (List<string>, List<string>) VerifyFileAccess(List<string> projectPaths, string solutionPath)
-        {
-            var projectsWithoutAccess = new List<string>();
-            var projectsWithAccess = new List<string>();
-
-            // Check Solution Path
-            if (!HaveDirectoryWriteAccess(Path.GetDirectoryName(solutionPath)))
-            {
-                return (projectPaths, projectsWithAccess);
-            }
-            // Check Projects
-            foreach (string project in projectPaths)
-            {
-                string projectFolderPath = Path.GetDirectoryName(project);
-                // assuming that a project doesn't exist in the root directory so won't be null
-                if (CheckWriteAccessForDirectory(projectFolderPath))
-                {
-                    projectsWithAccess.Add(project);
-                }
-                else
-                {
-                    projectsWithoutAccess.Add(project);
-                }
-            }
-            return (projectsWithoutAccess, projectsWithAccess);
-        }
-
-        /// <summary>
         /// Checks directory and all content for write access
         /// </summary>
         /// <param name="path">Directory path</param>
@@ -69,7 +33,7 @@ namespace PortingAssistant.Client.Common.Utils
                     return subDirectory;
                 }
                 string result = CheckWriteAccessForDirectory(subDirectory);
-                if (result != string.Empty)
+                if (!string.IsNullOrEmpty(result))
                 {
                     return result;
                 }

--- a/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
+++ b/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Security.Principal;
 using System.Security.AccessControl;
@@ -12,30 +12,25 @@ namespace PortingAssistant.Client.Common.Utils
         /// </summary>
         /// <param name="path">Directory path</param>
         /// <returns>First file/directory with no write access found if any, blank if all contents have access</returns>
-        public static string CheckWriteAccessForDirectory(string path)
+        public static List<string> CheckWriteAccessForDirectory(string path)
         {
+            var result = new List<string>();
             foreach (string file in Directory.GetFiles(path))
             {
                 if (!HaveFileWriteAccess(file))
                 {
-                    Console.WriteLine($"File {file} does not have write access");
-                    return file;
+                    result.Add(file);
                 }
             }
             foreach (string subDirectory in Directory.GetDirectories(path))
             {
                 if (!HaveDirectoryWriteAccess(subDirectory))
                 {
-                    Console.WriteLine($"Directory {subDirectory} does not have write access");
-                    return subDirectory;
+                    result.Add(subDirectory);
                 }
-                string result = CheckWriteAccessForDirectory(subDirectory);
-                if (!string.IsNullOrEmpty(result))
-                {
-                    return result;
-                }
+                result.AddRange(CheckWriteAccessForDirectory(subDirectory));
             }
-            return "";
+            return result;
         }
 
         private static bool HaveFileWriteAccess(string path)

--- a/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
+++ b/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Security.Principal;
-using System.Collections.Generic;
 using System.Security.AccessControl;
-using PortingAssistant.Client.Model;
 
 namespace PortingAssistant.Client.Common.Utils
 {
-    public static class FileSystem
+    public static class FileSystemAccess
     {
         /// <summary>
         /// Checks directory and all content for write access

--- a/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
+++ b/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
@@ -6,7 +6,7 @@ namespace PortingAssistant.Client.Common.Utils
 {
     public static class FileSystemAccess
     {
-        private static string[] fileTypesToCheck = { ".csproj", ".cs" };
+        private static readonly string[] fileTypesToCheck = { ".csproj", ".cs" };
 
         /// <summary>
         /// Checks directory and all content for write access
@@ -27,6 +27,27 @@ namespace PortingAssistant.Client.Common.Utils
                 result.AddRange(CheckWriteAccessForDirectory(subDirectory));
             }
             return result;
+        }
+
+        /// <summary>
+        /// Checks csproj and at least one .cs file is writeable
+        /// </summary>
+        /// <param name="path">Project file path</param>
+        /// <returns>True if csproj and at least one .cs file is writeable</returns>
+        public static bool CheckWriteAccessForProject(string path)
+        {
+            return CanWriteFile(path) &&
+                 DirectoryHasWriteableCSharpFile(Path.GetDirectoryName(path));
+        }
+
+        private static bool DirectoryHasWriteableCSharpFile(string directoryPath)
+        {
+            bool fileFound = Directory.GetFiles(directoryPath)
+                .Where(file => Path.GetExtension(file) == ".cs")
+                .Any(file => !CanWriteFile(file));
+
+            return fileFound || 
+                Directory.GetDirectories(directoryPath).Any(subDirectory => DirectoryHasWriteableCSharpFile(subDirectory));
         }
 
         private static bool CanWriteFile(string path)

--- a/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
+++ b/src/PortingAssistant.Client.Common/Utils/FileSystemAccess.cs
@@ -11,7 +11,7 @@ namespace PortingAssistant.Client.Common.Utils
         /// Checks directory and all content for write access
         /// </summary>
         /// <param name="path">Directory path</param>
-        /// <returns>First file/directory with no write access found if any, blank if all contents have access</returns>
+        /// <returns>List of items without write access</returns>
         public static List<string> CheckWriteAccessForDirectory(string path)
         {
             var result = new List<string>();

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
@@ -144,8 +144,8 @@ namespace PortingAssistant.Client.PortingProjectFile
 
             foreach (ProjectDetails project in projects)
             {
-                string result = Common.Utils.FileSystemAccess.CheckWriteAccessForDirectory(Path.GetDirectoryName(project.ProjectFilePath));
-                if (string.IsNullOrEmpty(result))
+                List<string> result = Common.Utils.FileSystemAccess.CheckWriteAccessForDirectory(Path.GetDirectoryName(project.ProjectFilePath));
+                if (result.Count == 0)
                 {
                     projectsWithAccess.Add(project);
                 }
@@ -156,7 +156,7 @@ namespace PortingAssistant.Client.PortingProjectFile
                         Success = false,
                         ProjectFile = project.ProjectFilePath,
                         ProjectName = project.ProjectName,
-                        Message = $"Application does not have write access to ${result} in project {project.ProjectName}",
+                        Message = $"Application does not have write access to items: ${string.Join(", ", result)}",
                         Exception = new UnauthorizedAccessException()
                     });
                 }

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
@@ -142,7 +142,7 @@ namespace PortingAssistant.Client.PortingProjectFile
 
             foreach (ProjectDetails project in projects)
             {
-                string result = Common.Utils.FileSystem.CheckWriteAccessForDirectory(Path.GetDirectoryName(project.ProjectFilePath));
+                string result = Common.Utils.FileSystemAccess.CheckWriteAccessForDirectory(Path.GetDirectoryName(project.ProjectFilePath));
                 if (string.IsNullOrEmpty(result))
                 {
                     projectsWithAccess.Add(project);

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
@@ -67,7 +67,7 @@ namespace PortingAssistant.Client.PortingProjectFile
             }));
             projects = projects.Where((p) => File.Exists(p.ProjectFilePath)).ToList();
 
-            var (projectsWithAccess, noAccessPortingResults) = VerifyFileAccess(projects, solutionPath);
+            var (projectsWithAccess, noAccessPortingResults) = VerifyFileAccess(projects);
             results.AddRange(noAccessPortingResults);
             projects = projectsWithAccess;
 
@@ -130,22 +130,20 @@ namespace PortingAssistant.Client.PortingProjectFile
         }
 
         /// <summary>
-        /// Checks solution and project folders to make sure we have write access
+        /// Checks projects to make sure we have access to the project file and at least one csharp file
         /// </summary>
         /// <param name="projects">List of projects to check for write access</param>
-        /// <param name="solutionPath">Path to solution file</param>
         /// <returns>
         /// Valid projects with access, Porting result for projects without access
         /// </returns>
-        private (List<ProjectDetails>, List<PortingResult>) VerifyFileAccess(List<ProjectDetails> projects, string solutionPath)
+        private (List<ProjectDetails>, List<PortingResult>) VerifyFileAccess(List<ProjectDetails> projects)
         {
             var noAccessPortingResults = new List<PortingResult>();
             var projectsWithAccess = new List<ProjectDetails>();
 
             foreach (ProjectDetails project in projects)
             {
-                List<string> result = Common.Utils.FileSystemAccess.CheckWriteAccessForDirectory(Path.GetDirectoryName(project.ProjectFilePath));
-                if (result.Count == 0)
+                if (Common.Utils.FileSystemAccess.CheckWriteAccessForProject(project.ProjectFilePath))
                 {
                     projectsWithAccess.Add(project);
                 }
@@ -156,7 +154,7 @@ namespace PortingAssistant.Client.PortingProjectFile
                         Success = false,
                         ProjectFile = project.ProjectFilePath,
                         ProjectName = project.ProjectName,
-                        Message = $"Application does not have write access to items: ${string.Join(", ", result)}",
+                        Message = $"Application does not have write access to project: ${project.ProjectName}",
                         Exception = new UnauthorizedAccessException()
                     });
                 }


### PR DESCRIPTION

#### Description of change
Add method to check file write access for directory and its contents, check before porting and only port projects that have permissions to everything within

#### Issue
#88 

#### PR reviewer notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
