### PR TITLE
Package and publish CLI executable to S3 bucket.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -33,7 +33,9 @@ jobs:
       run: dotnet test --configuration Release --no-restore --verbosity normal
     - name: Pack
       if: ${{ github.event_name == 'push' }}
-      run: dotnet pack --configuration Release --no-restore -o dist
+      run: |
+        dotnet pack --configuration Release --no-restore -o dist
+        dotnet publish src/PortingAssistant.Client/PortingAssistant.Client.CLI.csproj -r win-x64 -p:PublishSingleFile=true /p:DebugType=None /p:DebugSymbols=false --self-contained false -f netcoreapp3.1 -o dist
     - name: Install Sleet
       if: ${{ github.event_name == 'push' }}
       run: dotnet tool install -g sleet --version 3.2.0
@@ -47,3 +49,12 @@ jobs:
     - name: Publish
       if: ${{ github.event_name == 'push' }}
       run: sleet push dist --source s3Feed --verbose
+    - name: Publish CLI Executable
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        Get-ChildItem ./dist/PortingAssistant.Client.CLI.*.nupkg | Foreach-Object { 
+        $version =  $_.Name -replace 'PortingAssistant.Client.CLI.', '' -replace ‘.nupkg’, ‘’
+        }
+        $uploadLink = 's3://aws.portingassistant.dotnet.download/nuget/flatcontainer/portingassistant.client.cli/' + $version + '/'
+        Echo $uploadLink
+        aws s3 cp ./dist/PortingAssistant.Client.CLI.exe $uploadLink


### PR DESCRIPTION
#### Description of change
This patch pacakges and publish `PortingAssistant.Client.CLI.exe` to S3 bucket.

We are using `Nerdbank.GitVersioning` for semantic versioning. It
automatically setup the version number for each project and upload them
to our private nuget repo on S3 bucket structured by version. This patch packages
`PortingAssistant.Client.CLI.exe` and upload it to the corresponding
versioned S3 subfolder.

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
