### PR TITLE
Fix ThrowAddingDuplicateWithKeyArgumentException.

### DIFF
--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -135,6 +135,7 @@ namespace PortingAssistant.Client.Client
                         var packageRecommendation = (PackageRecommendation)recommendation;
                         return new Tuple<string, Tuple<string, string>>(packageRecommendation.PackageId, new Tuple<string, string>(packageRecommendation.Version, packageRecommendation.TargetVersions.First()));
                     })
+                    .GroupBy(t => t.Item1).Select(t => t.FirstOrDefault())
                     .ToDictionary(t => t.Item1, t => t.Item2);
 
                 return _portingHandler.ApplyPortProjectFileChanges(


### PR DESCRIPTION
#### Description of change
ApplyPortingChanges does an aggregation on the RecommendedActions across all projects being ported based on the package ID and generate a dictionary. When more than one project in a solution depend on a same package, the aggregation throws  ThrowAddingDuplicateWithKeyArgumentException due to duplicated key with the same package ID. This patch fix the issue by apply GroupBy before converting to dictionary.

#### Issue
#320 

#### PR reviewer notes
I've manually tested it againt nopcommerce by porting Nop.Core.csproj and Nop.Services.csproj where both projects depend on Autoflac pacakge. With this change the exception is no longer thrown.

I will add an integration test separately for this error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
