### PR TITLE
Portproject skips projects with provided project names.

### DIFF
--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -103,7 +103,7 @@ namespace PortingAssistant.Client.CLI
                         var PortingRequest = new PortingRequest
                         {
 
-                            Projects = analyzeResults.Result.SolutionDetails.Projects.Where(p => cli.PortingProjects.Contains(p.ProjectFilePath)).ToList(),
+                            Projects = analyzeResults.Result.SolutionDetails.Projects.Where(p => cli.PortingProjects.Contains(p.ProjectName)).ToList(),
                             SolutionPath = cli.SolutionPath,
                             TargetFramework = cli.Target.ToString(),
                             RecommendedActions = FilteredRecommendedActions.ToList(),

--- a/tests/PortingAssistant.Client.IntegrationTests/RunPortingCorrectnessWithDotNetFramework.cs
+++ b/tests/PortingAssistant.Client.IntegrationTests/RunPortingCorrectnessWithDotNetFramework.cs
@@ -97,7 +97,7 @@ namespace PortingAssistant.Client.IntegrationTests
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;
             startInfo.Arguments = "assess -s " + actualTestSolutionPath
                 + " " + "-o " + actualAnalysisResultRootDir
-                + " " + "-p " + actualTestProjectPath;
+                + " " + "-p " + "NetFrameworkExample";
 
             try
             {


### PR DESCRIPTION
The issue is due to a bug when we are checking for provided projects to port by path but the provided projects are names.

#### PR reviewer notes
Updated corresponding integration test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
