### PR TITLE
Fix NullReferenceException.

### DIFF
--- a/src/PortingAssistant.Client.Client/FileParser/GitConfigFileParser.cs
+++ b/src/PortingAssistant.Client.Client/FileParser/GitConfigFileParser.cs
@@ -26,7 +26,7 @@ namespace PortingAssistant.Client.Client.FileParser
 
         public static string getGitRepositoryUrl(string gitRepositoryRootPath)
         {
-            if (!Directory.Exists(gitRepositoryRootPath))
+            if (gitRepositoryRootPath == null || !Directory.Exists(gitRepositoryRootPath))
             {
                 return null;
             }


### PR DESCRIPTION
System.NullReferenceException: Object reference not set to an instance of an object.    at PortingAssistant.Client.Client.FileParser.GitConfigFileParser.getGitRepositoryUrl(String gitRepositoryRootPath)    at PortingAssistant.Client.Client.PortingAssistantClient.AnalyzeSolutionAsync(String solutionFilePath, AnalyzerSettings settings)

This is the fix for above exception.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
