### PR TITLE
Add tag option to allow third party mark the metrics source.

### DIFF
--- a/src/PortingAssistant.Client/PortingAssistantCLI.cs
+++ b/src/PortingAssistant.Client/PortingAssistantCLI.cs
@@ -27,6 +27,9 @@ namespace PortingAssistant.Client.CLI
         [Option('p', "porting-projects", Separator = ',', Required = false, HelpText = "porting projects")]
         public IEnumerable<string> PortingProjects { get; set; }
 
+        [Option('g', "tag", Required = false, Default = "client", HelpText = "tag the metrics source with: MH, drift or client, by default is client")]
+        public string Tag { get; set; }
+
 
         [Usage(ApplicationAlias = "Porting Assistant Client")]
         public static IEnumerable<Example> Examples
@@ -56,6 +59,7 @@ namespace PortingAssistant.Client.CLI
         public List<string> IgnoreProjects;
         public List<string> PortingProjects;
         public string Target;
+        public string Tag;
 
         public bool isAssess = false;
         public bool isSchema = false;
@@ -64,6 +68,7 @@ namespace PortingAssistant.Client.CLI
         public void HandleCommand(String[] args)
         {
             var TargetFrameworks = new HashSet<string> { "net5.0", "netcoreapp3.1", "netstandard2.1" };
+            var Tags = new HashSet<string> { "mh", "drift", "client" };
 
             Parser.Default.ParseArguments<AssessOptions, SchemaOptions>(args)
                 .WithNotParsed(HandleParseError)
@@ -90,6 +95,13 @@ namespace PortingAssistant.Client.CLI
                         Environment.Exit(-1);
                     }
                     Target = o.Target;
+
+                    if (!Tags.Contains(o.Tag.ToLower()))
+                    {
+                        Console.WriteLine("Invalid tag " + OutputPath);
+                        Environment.Exit(-1);
+                    }
+                    Tag = o.Tag;
 
                     if (o.IgnoreProjects != null)
                     {

--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -91,7 +91,7 @@ namespace PortingAssistant.Client.CLI
                     if (analyzeResults.IsCompletedSuccessfully)
                     {
                         reportExporter.GenerateJsonReport(analyzeResults.Result, cli.OutputPath);
-                        TelemetryCollector.SolutionAssessmentCollect(analyzeResults.Result, cli.Target, "1.8.0", "Porting Assistant Client CLI", DateTime.Now.Subtract(startTime).TotalMilliseconds);
+                        TelemetryCollector.SolutionAssessmentCollect(analyzeResults.Result, cli.Target, "1.8.0", $"Porting Assistant {cli.Tag.ToUpper()} CLI", DateTime.Now.Subtract(startTime).TotalMilliseconds);
                     }
                     else
                     {


### PR DESCRIPTION
#### Description of change
Add tag option. The value of the tag argument will be used as part of the metrics source name. This helps Porting Assistant ops to identify metrics source.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
