### PR TITLE
Add user provided tag to log entry.

### DIFF
--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -39,7 +39,7 @@ namespace PortingAssistant.Client.CLI
             var metricsFilePath = Path.Combine(logs, "portingAssistant-client-cli.metrics");
 
             string version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
-            var outputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] (Porting Assistant Client CLI) (" + version + ") {SourceContext}: {Message:lj}{NewLine}{Exception}";
+            var outputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] (Porting Assistant Client CLI) (" + version + ") (" + cli.Tag + ") {SourceContext}: {Message:lj}{NewLine}{Exception}";
 
             Serilog.Formatting.Display.MessageTemplateTextFormatter tf =
                 new Serilog.Formatting.Display.MessageTemplateTextFormatter(outputTemplate, CultureInfo.InvariantCulture);

--- a/tests/PortingAssistant.Client.IntegrationTests/RunWithDotNetCoreFrameowrk.cs
+++ b/tests/PortingAssistant.Client.IntegrationTests/RunWithDotNetCoreFrameowrk.cs
@@ -231,7 +231,7 @@ namespace PortingAssistant.Client.IntegrationTests
             Assert.AreEqual(Compatibility.COMPATIBLE, apiAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").Compatibility);
             Assert.True(apiAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").CompatibleVersions.Count > 0);
             Assert.AreEqual(RecommendedActionType.UpgradePackage, apiAnalysisResult.Recommendations.RecommendedActions.First().RecommendedActionType);
-            Assert.AreEqual("2.8.0", apiAnalysisResult.Recommendations.RecommendedActions.First().Description);
+            Assert.AreEqual("2.10.0", apiAnalysisResult.Recommendations.RecommendedActions.First().Description);
 
 
             var blogController = sourceFileAnalysisResults.Find(s => s.SourceFileName == "BlogController.cs");

--- a/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-api-analysis.json
+++ b/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-api-analysis.json
@@ -1,5 +1,4 @@
 {
-  "SchemaVersion":  "1.0",
   "SolutionFile": "NetFrameworkExample",
   "SolutionGuid": "8602089b-96fd-4fa4-9b4d-36067c03e572",
   "ApplicationGuid": "8602089b-96fd-4fa4-9b4d-36067c03e572",
@@ -7,10 +6,11 @@
   "ProjectFile": "NetFrameworkExample",
   "ProjectGuid": null,
   "Errors": [],
+  "SchemaVersion": "1.0",
   "SourceFileAnalysisResults": [
     {
       "SourceFileName": "BundleConfig.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\BundleConfig.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\BundleConfig.cs",
       "ApiAnalysisResults": [
         {
           "CodeEntityDetails": {
@@ -625,7 +625,7 @@
     },
     {
       "SourceFileName": "FilterConfig.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\FilterConfig.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\FilterConfig.cs",
       "ApiAnalysisResults": [
         {
           "CodeEntityDetails": {
@@ -762,7 +762,7 @@
             {
               "NewText": "using Microsoft.AspNetCore.Mvc;\r\n\r\nnamespace NetFrameworkExample\r\n{\r\n    public class FilterConfig\r\n    {\r\n        public static void RegisterGlobalFilters(GlobalFilterCollection filters)\r\n        {\r\n            filters.Add(new HandleErrorAttribute());\r\n        }\r\n    }\r\n}",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\FilterConfig.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\FilterConfig.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 2,
@@ -788,7 +788,7 @@
             {
               "NewText": "\r\nnamespace NetFrameworkExample\r\n{\r\n    public class FilterConfig\r\n    {\r\n        public static void RegisterGlobalFilters(GlobalFilterCollection filters)\r\n        {\r\n            filters.Add(new HandleErrorAttribute());\r\n        }\r\n    }\r\n}",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\FilterConfig.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\FilterConfig.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 1,
@@ -817,7 +817,7 @@
     },
     {
       "SourceFileName": "RouteConfig.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\RouteConfig.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\RouteConfig.cs",
       "ApiAnalysisResults": [
         {
           "CodeEntityDetails": {
@@ -954,7 +954,7 @@
             {
               "NewText": "using Microsoft.AspNetCore.Mvc;\r\n\r\nnamespace NetFrameworkExample\r\n{\r\n    public class RouteConfig\r\n    {\r\n        public static void RegisterRoutes(RouteCollection routes)\r\n        {\r\n            routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\r\n            routes.MapRoute(name: \"Default\", url: \"{controller}/{action}/{id}\", defaults: new\r\n            {\r\n            controller = \"Home\", action = \"Index\", id = UrlParameter.Optional\r\n            }\r\n\r\n            );\r\n        }\r\n    }\r\n}",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\RouteConfig.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\RouteConfig.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 6,
@@ -980,7 +980,7 @@
             {
               "NewText": "Routing;\r\n\r\nnamespace NetFrameworkExample\r\n{\r\n    public class RouteConfig\r\n    {\r\n        public static void RegisterRoutes(RouteCollection routes)\r\n        {\r\n            routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\r\n            routes.MapRoute(name: \"Default\", url: \"{controller}/{action}/{id}\", defaults: new\r\n            {\r\n            controller = \"Home\", action = \"Index\", id = UrlParameter.Optional\r\n            }\r\n\r\n            );\r\n        }\r\n    }\r\n}",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\RouteConfig.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\App_Start\\RouteConfig.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 4,
@@ -1009,7 +1009,7 @@
     },
     {
       "SourceFileName": "HomeController.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Controllers\\HomeController.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Controllers\\HomeController.cs",
       "ApiAnalysisResults": [
         {
           "CodeEntityDetails": {
@@ -1260,7 +1260,7 @@
             {
               "NewText": "using Microsoft.AspNetCore.Mvc;\r\n\r\nnamespace NetFrameworkExample.Controllers\r\n{\r\n    public class HomeController : Controller\r\n    {\r\n        public ActionResult Index()\r\n        {\r\n            return View();\r\n        }\r\n\r\n        public ActionResult About()\r\n        {\r\n            ViewBag.Message = \"Your application description page.\";\r\n            return View();\r\n        }\r\n\r\n        public ActionResult Contact()\r\n        {\r\n            ViewBag.Message = \"Your contact page.\";",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Controllers\\HomeController.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Controllers\\HomeController.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 5,
@@ -1286,7 +1286,7 @@
             {
               "NewText": "\r\nnamespace NetFrameworkExample.Controllers\r\n{\r\n    public class HomeController : Controller\r\n    {\r\n        public ActionResult Index()\r\n        {\r\n            return View();\r\n        }\r\n\r\n        public ActionResult About()\r\n        {\r\n            ViewBag.Message = \"Your application description page.\";\r\n            return View();\r\n        }\r\n\r\n        public ActionResult Contact()\r\n        {\r\n            ViewBag.Message = \"Your contact page.\";",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Controllers\\HomeController.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Controllers\\HomeController.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 4,
@@ -1315,7 +1315,7 @@
     },
     {
       "SourceFileName": "Global.asax.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Global.asax.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Global.asax.cs",
       "ApiAnalysisResults": [
         {
           "CodeEntityDetails": {
@@ -1376,7 +1376,7 @@
             {
               "NewText": "using Microsoft.AspNetCore.Mvc;\r\n\r\nnamespace NetFrameworkExample\r\n{\r\n    public class MvcApplication : System.Web.HttpApplication\r\n    {\r\n        protected void Application_Start()\r\n        {\r\n            AreaRegistration.RegisterAllAreas();\r\n            FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\r\n            RouteConfig.RegisterRoutes(RouteTable.Routes);\r\n            BundleConfig.RegisterBundles(BundleTable.Bundles);\r\n        }\r\n    }\r\n}",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Global.asax.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Global.asax.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 7,
@@ -1402,7 +1402,7 @@
             {
               "NewText": "Optimization;\r\nusing System.Web.Routing;\r\n\r\nnamespace NetFrameworkExample\r\n{\r\n    public class MvcApplication : System.Web.HttpApplication\r\n    {\r\n        protected void Application_Start()\r\n        {\r\n            AreaRegistration.RegisterAllAreas();\r\n            FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\r\n            RouteConfig.RegisterRoutes(RouteTable.Routes);\r\n            BundleConfig.RegisterBundles(BundleTable.Bundles);\r\n        }\r\n    }\r\n}",
               "FileLinePositionSpan": {
-                "Path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Global.asax.cs",
+                "Path": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Global.asax.cs",
                 "HasMappedPath": false,
                 "StartLinePosition": {
                   "_line": 4,
@@ -1431,13 +1431,13 @@
     },
     {
       "SourceFileName": "AssemblyInfo.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\Properties\\AssemblyInfo.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\Properties\\AssemblyInfo.cs",
       "ApiAnalysisResults": [],
       "RecommendedActions": []
     },
     {
       "SourceFileName": ".NETFramework,Version=v4.8.AssemblyAttributes.cs",
-      "SourceFilePath": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\2\\0zb2zwzp.oir\\NetFrameworkExample\\NetFrameworkExample\\obj\\Debug\\.NETFramework,Version=v4.8.AssemblyAttributes.cs",
+      "SourceFilePath": "C:\\Users\\hshans\\AppData\\Local\\Temp\\0q2n3qci.gfv\\NetFrameworkExample\\NetFrameworkExample\\obj\\Debug\\.NETFramework,Version=v4.8.AssemblyAttributes.cs",
       "ApiAnalysisResults": [],
       "RecommendedActions": []
     }

--- a/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-package-analysis.json
+++ b/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-package-analysis.json
@@ -48,7 +48,14 @@
           "4.5.0",
           "4.5.1",
           "4.5.2",
-          "4.5.3"
+          "4.5.3",
+          "4.6.0",
+          "5.0.0",
+          "5.0.1",
+          "5.0.2",
+          "5.1.0",
+          "5.1.1",
+          "5.1.2"
         ]
       }
     },
@@ -70,7 +77,14 @@
             "4.5.0",
             "4.5.1",
             "4.5.2",
-            "4.5.3"
+            "4.5.3",
+            "4.6.0",
+            "5.0.0",
+            "5.0.1",
+            "5.0.2",
+            "5.1.0",
+            "5.1.1",
+            "5.1.2"
           ],
           "RecommendedActionType": "UpgradePackage",
           "Description": "4.0.0",
@@ -93,7 +107,8 @@
         "CompatibleVersions": [
           "3.5.0",
           "3.5.0.1",
-          "3.5.1"
+          "3.5.1",
+          "3.6.0"
         ]
       }
     },
@@ -105,7 +120,8 @@
           "TargetVersions": [
             "3.5.0",
             "3.5.0.1",
-            "3.5.1"
+            "3.5.1",
+            "3.6.0"
           ],
           "RecommendedActionType": "UpgradePackage",
           "Description": "3.5.0",
@@ -293,7 +309,9 @@
     "CompatibilityResults": {
       "netcoreapp3.1": {
         "Compatibility": "COMPATIBLE",
-        "CompatibleVersions": []
+        "CompatibleVersions": [
+          "3.2.12"
+        ]
       }
     },
     "Recommendations": {
@@ -301,9 +319,11 @@
         {
           "PackageId": "Microsoft.jQuery.Unobtrusive.Validation",
           "Version": null,
-          "TargetVersions": [],
+          "TargetVersions": [
+            "3.2.12"
+          ],
           "RecommendedActionType": "UpgradePackage",
-          "Description": null,
+          "Description": "3.2.12",
           "TextSpan": null,
           "TargetCPU": null,
           "TextChanges": null
@@ -375,7 +395,8 @@
       "netcoreapp3.1": {
         "Compatibility": "COMPATIBLE",
         "CompatibleVersions": [
-          "12.0.3"
+          "12.0.3",
+          "13.0.1"
         ]
       }
     },
@@ -385,7 +406,8 @@
           "PackageId": "Newtonsoft.Json",
           "Version": null,
           "TargetVersions": [
-            "12.0.3"
+            "12.0.3",
+            "13.0.1"
           ],
           "RecommendedActionType": "UpgradePackage",
           "Description": "12.0.3",


### PR DESCRIPTION
#### Description of change
Add user provided tag to log entry. This helps us to identify the source of assessment/porting errors.

log entry looks like the following with the new change:
```
[2021-11-19 10:57:52 DBG] (Porting Assistant Client CLI) (1.11.15-alpha+86dca5076b) (Drift-1.0.0) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: CallerInfo: PortingAssistantAnalysisHandler.AnalyzeProject
[2021-11-19 10:57:52 DBG] (Porting Assistant Client CLI) (1.11.15-alpha+86dca5076b) (Drift-1.0.0) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: Memory used before collection:       62,316,504
[2021-11-19 10:57:52 DBG] (Porting Assistant Client CLI) (1.11.15-alpha+86dca5076b) (Drift-1.0.0) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: Memory used after full collection:   39,086,376
[2021-11-19 10:57:52 INF] (Porting Assistant Client CLI) (1.11.15-alpha+86dca5076b) (Drift-1.0.0) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: Memory Consumption after AnalyzeProjects: 

```
[//]: # (What are you trying to fix? What did you change)

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
