### PR TITLE
feat: add file line map to track metrics data already sent

### DIFF
--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -129,23 +129,24 @@ namespace PortingAssistant.Client.CLI
                         reportExporter.GenerateJsonReport(portingResults, cli.SolutionPath, cli.OutputPath);
 
                     }
-                    UploadLogs(cli.Profile, telemetryConfiguration, logFilePath, metricsFilePath);
+                    UploadLogs(cli.Profile, telemetryConfiguration, logFilePath, metricsFilePath, logs);
                 }
                 catch (Exception ex)
                 {
                     Log.Logger.Error(ex, "error when using the tools :");
-                    UploadLogs(cli.Profile, telemetryConfiguration, logFilePath, metricsFilePath);
+                    UploadLogs(cli.Profile, telemetryConfiguration, logFilePath, metricsFilePath, logs);
                     Environment.Exit(-1);
                 }
             }
         }
 
-        private static void UploadLogs(string profile, TelemetryConfiguration telemetryConfiguration, string logFilePath, string metricsFilePath)
+        private static void UploadLogs(string profile, TelemetryConfiguration telemetryConfiguration, string logFilePath, string metricsFilePath, string logsPath)
         {
             if (!string.IsNullOrEmpty(profile))
             {
                 telemetryConfiguration.LogFilePath = logFilePath;
                 telemetryConfiguration.MetricsFilePath = metricsFilePath;
+                telemetryConfiguration.LogsPath = logsPath;
                 var isSuccessed = Uploader.Upload(telemetryConfiguration, new System.Net.Http.HttpClient(), profile, "");
 
                 if (!isSuccessed)

--- a/tests/PortingAssistant.Client.IntegrationTests/RunAnalysisCorrectnessWithDotNetFramework.cs
+++ b/tests/PortingAssistant.Client.IntegrationTests/RunAnalysisCorrectnessWithDotNetFramework.cs
@@ -109,7 +109,7 @@ namespace PortingAssistant.Client.IntegrationTests
                expectedAnalysisResultRootDir,
                "Schemas",
                "package-analysis-schema.json");
-            Assert.IsTrue(JsonUtils.ValidateSchema(actualPackageAnalysisPath, packageAnalysisSchemaPath, true));
+            Assert.IsTrue(JsonUtils.ValidateSchema(actualPackageAnalysisPath, packageAnalysisSchemaPath, true), "Package analysis schema does not match expected");
 
             string actualApiAnalysisPath = Path.Combine(
                 actualAnalysisResultRootDir,
@@ -121,7 +121,7 @@ namespace PortingAssistant.Client.IntegrationTests
                expectedAnalysisResultRootDir,
                "Schemas",
                "api-analysis-schema.json");
-            Assert.IsTrue(JsonUtils.ValidateSchema(actualApiAnalysisPath, apiAnalysisSchemaPath, false));
+            Assert.IsTrue(JsonUtils.ValidateSchema(actualApiAnalysisPath, apiAnalysisSchemaPath, false), "API analysis schema does not match expected");
         }
     }
 }

--- a/tests/PortingAssistant.Client.IntegrationTests/RunAnalysisCorrectnessWithDotNetFramework.cs
+++ b/tests/PortingAssistant.Client.IntegrationTests/RunAnalysisCorrectnessWithDotNetFramework.cs
@@ -78,7 +78,7 @@ namespace PortingAssistant.Client.IntegrationTests
             string[] propertiesToBeRemovedInPackageAnalysisResult = { };
             Assert.IsTrue(JsonUtils.AreTwoJsonFilesEqual(
                 expectedPackageAnalysisPath, actualPackageAnalysisPath,
-                propertiesToBeRemovedInPackageAnalysisResult));
+                propertiesToBeRemovedInPackageAnalysisResult), "Package analysis did not match expected");
 
             string expectedApiAnalysisPath = Path.Combine(
                 expectedAnalysisResultRootDir,
@@ -94,7 +94,7 @@ namespace PortingAssistant.Client.IntegrationTests
             bool comparisonResult = JsonUtils.AreTwoJsonFilesEqual(
                 expectedApiAnalysisPath, actualApiAnalysisPath,
                 propertiesToBeRemovedInApiAnalysisResult);
-            Assert.IsTrue(comparisonResult);
+            Assert.IsTrue(comparisonResult, "API analysis did not match expected");
         }
 
         private void ValidateSchemas()

--- a/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-package-analysis.json
+++ b/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-package-analysis.json
@@ -143,7 +143,8 @@
         "Compatibility": "COMPATIBLE",
         "CompatibleVersions": [
           "1.19.1",
-          "1.19.2"
+          "1.19.2",
+          "1.19.3"
         ]
       }
     },
@@ -154,7 +155,8 @@
           "Version": null,
           "TargetVersions": [
             "1.19.1",
-            "1.19.2"
+            "1.19.2",
+            "1.19.3"
           ],
           "RecommendedActionType": "UpgradePackage",
           "Description": "1.19.1",

--- a/tests/PortingAssistant.Client.IntegrationTests/TestUtils/JsonUtils.cs
+++ b/tests/PortingAssistant.Client.IntegrationTests/TestUtils/JsonUtils.cs
@@ -48,8 +48,8 @@ namespace PortingAssistant.Client.IntegrationTests.TestUtils
             }
 
             JObject patch = FindJsonDiff(jObject1, jObject2);
-            // Console.WriteLine("---------DIFF-----------");
-            // Console.WriteLine(patch.ToString());
+            Console.WriteLine("---------DIFF-----------");
+            Console.WriteLine(patch.ToString());
             return patch.Count == 0;
         }
 


### PR DESCRIPTION
#### Description of change
Add JSON file to store last line of metrics/logs that were uploaded to telemetry endpoint.

#### Issue
Resolves #857 

#### PR reviewer notes
Currently this will not introduce any rolling interval to the log/metric files. The upload has the file paths passed directly so more work probably needs to be done to have the files roll each day and ensure we aren't missing and logs from previous days.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
