### PR TITLE
Fix compatibility

### DIFF
--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -373,9 +373,12 @@ namespace PortingAssistant.Client.Analysis
                         .Select((project) => new KeyValuePair<string, ProjectAnalysisResult>(
                             project,
                             AnalyzeProject(
-                                project, solutionFileName,
-                                analyzerResult, analysisActions,
-                                isIncremental, targetFramework)))
+                                project,
+                                solutionFileName,
+                                analyzerResult,
+                                analysisActions,
+                                isIncremental,
+                                targetFramework)))
                         .Where(p => p.Value != null)
                         .ToDictionary(p => p.Key, p => p.Value);
 
@@ -423,12 +426,18 @@ namespace PortingAssistant.Client.Analysis
                 var nugetPackages = analyzer.ProjectResult.ExternalReferences.NugetReferences
                     .Select(r => CodeEntityModelToCodeEntities.ReferenceToPackageVersionPair(r))
                     .ToHashSet();
+                var nugetPackageNameLookup = nugetPackages.Select(package => package.PackageId).ToHashSet();
 
                 var subDependencies = analyzer.ProjectResult.ExternalReferences.NugetDependencies
                     .Select(r => CodeEntityModelToCodeEntities.ReferenceToPackageVersionPair(r))
                     .ToHashSet();
 
-                var sdkPackages = namespaces.Select(n => new PackageVersionPair { PackageId = n, Version = "0.0.0", PackageSourceType = PackageSourceType.SDK });
+                var sdkPackages = namespaces.Select(n => new PackageVersionPair
+                {
+                    PackageId = n,
+                    Version = "0.0.0",
+                    PackageSourceType = PackageSourceType.SDK
+                }).Where(pair => !nugetPackageNameLookup.Contains(pair.PackageId));
 
                 var allPackages = nugetPackages
                     .Union(subDependencies)

--- a/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
@@ -95,18 +95,22 @@ namespace PortingAssistant.Client.Analysis.Utils
                     return semversion.CompareTo(version) > 0;
                 }).ToList();
 
+                var compatibility = foundTarget.Any(v =>
+                {
+                    if (!NuGetVersion.TryParse(v, out var semversion))
+                    {
+                        return false;
+                    }
+
+                    return version.CompareTo(semversion) == 0;
+                })
+                    ? Compatibility.COMPATIBLE
+                    : Compatibility.INCOMPATIBLE;
+
                 compatibleVersions.Sort( (a, b) => NuGetVersion.Parse(a).CompareTo(NuGetVersion.Parse(b)));
                 return new CompatibilityResult
                 {
-                    Compatibility = foundTarget.Any(v =>
-                    {
-                        if (!NuGetVersion.TryParse(v, out var semversion))
-                        {
-                            return false;
-                        }
-
-                        return version.CompareTo(semversion) >= 0;
-                    }) ? Compatibility.COMPATIBLE : Compatibility.INCOMPATIBLE,
+                    Compatibility = compatibility,
                     CompatibleVersions = compatibleVersions
                 };
             }

--- a/tests/PortingAssistant.Client.IntegrationTests/RunWithDotNetFramework.cs
+++ b/tests/PortingAssistant.Client.IntegrationTests/RunWithDotNetFramework.cs
@@ -108,8 +108,8 @@ namespace PortingAssistant.Client.IntegrationTests
                 Version = "3.4.1",
                 PackageSourceType = PackageSourceType.NUGET
             }).Result;
-            Assert.AreEqual(Compatibility.COMPATIBLE, packageAnalysisResult.CompatibilityResults.
-            GetValueOrDefault("netcoreapp3.1").Compatibility);
+            Assert.AreEqual(Compatibility.COMPATIBLE, 
+                packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").Compatibility);
             Assert.True(packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").CompatibleVersions.Count > 0);
             Assert.AreEqual(RecommendedActionType.UpgradePackage, packageAnalysisResult.Recommendations.RecommendedActions.First().RecommendedActionType);
             Assert.AreEqual("4.0.0", packageAnalysisResult.Recommendations.RecommendedActions.First().Description);
@@ -120,8 +120,8 @@ namespace PortingAssistant.Client.IntegrationTests
                 Version = "2.0.1",
                 PackageSourceType = PackageSourceType.NUGET
             }).Result;
-            Assert.AreEqual(Compatibility.COMPATIBLE, packageAnalysisResult.CompatibilityResults.
-            GetValueOrDefault("netcoreapp3.1").Compatibility);
+            Assert.AreEqual(Compatibility.INCOMPATIBLE, 
+                packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").Compatibility);
             Assert.AreEqual(0, packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").CompatibleVersions.Count);
             Assert.AreEqual(RecommendedActionType.UpgradePackage, packageAnalysisResult.Recommendations.RecommendedActions.First().RecommendedActionType);
             Assert.Null(packageAnalysisResult.Recommendations.RecommendedActions.First().Description);
@@ -132,8 +132,8 @@ namespace PortingAssistant.Client.IntegrationTests
                 Version = "12.0.2",
                 PackageSourceType = PackageSourceType.NUGET
             }).Result;
-            Assert.AreEqual(Compatibility.COMPATIBLE, packageAnalysisResult.CompatibilityResults.
-            GetValueOrDefault("netcoreapp3.1").Compatibility);
+            Assert.AreEqual(Compatibility.COMPATIBLE, 
+                packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").Compatibility);
             Assert.True(packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").CompatibleVersions.Count > 0);
             Assert.AreEqual(RecommendedActionType.UpgradePackage, packageAnalysisResult.Recommendations.RecommendedActions.First().RecommendedActionType);
             Assert.AreEqual("12.0.3", packageAnalysisResult.Recommendations.RecommendedActions.First().Description);
@@ -144,8 +144,8 @@ namespace PortingAssistant.Client.IntegrationTests
                 Version = "3.5.0.2",
                 PackageSourceType = PackageSourceType.NUGET
             }).Result;
-            Assert.AreEqual(Compatibility.INCOMPATIBLE, packageAnalysisResult.CompatibilityResults.
-            GetValueOrDefault("netcoreapp3.1").Compatibility);
+            Assert.AreEqual(Compatibility.INCOMPATIBLE, 
+                packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").Compatibility);
             Assert.AreEqual(0, packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").CompatibleVersions.Count);
             Assert.AreEqual(RecommendedActionType.UpgradePackage, packageAnalysisResult.Recommendations.RecommendedActions.First().RecommendedActionType);
             Assert.Null(packageAnalysisResult.Recommendations.RecommendedActions.First().Description);
@@ -156,8 +156,8 @@ namespace PortingAssistant.Client.IntegrationTests
                 Version = "5.2.7",
                 PackageSourceType = PackageSourceType.NUGET
             }).Result;
-            Assert.AreEqual(Compatibility.INCOMPATIBLE, packageAnalysisResult.CompatibilityResults.
-            GetValueOrDefault("netcoreapp3.1").Compatibility);
+            Assert.AreEqual(Compatibility.INCOMPATIBLE, 
+                packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").Compatibility);
             Assert.AreEqual(0, packageAnalysisResult.CompatibilityResults.GetValueOrDefault("netcoreapp3.1").CompatibleVersions.Count);
             Assert.AreEqual(RecommendedActionType.UpgradePackage, packageAnalysisResult.Recommendations.RecommendedActions.First().RecommendedActionType);
             Assert.Null(packageAnalysisResult.Recommendations.RecommendedActions.First().Description);

--- a/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-package-analysis.json
+++ b/tests/PortingAssistant.Client.IntegrationTests/TestProjects/NetFrameworkExample-analyze/NetFrameworkExample-package-analysis.json
@@ -283,7 +283,7 @@
     },
     "CompatibilityResults": {
       "netcoreapp3.1": {
-        "Compatibility": "COMPATIBLE",
+        "Compatibility": "INCOMPATIBLE",
         "CompatibleVersions": []
       }
     },

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantRecommendationTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantRecommendationTest.cs
@@ -183,5 +183,35 @@ namespace PortingAssistant.Client.UnitTests
             Assert.AreEqual(1, recommendation.CompatibilityResults["netcoreapp3.1"].CompatibleVersions.Count);
             Assert.AreEqual("2.0.0", recommendation.Recommendations.RecommendedActions[0].Description);
         }
+
+        [Test]
+        public void TestIsCompatibleAsync_ReturnsIncompatible_PackageVersionNotInTargetVersions()
+        {
+            var versions = new SortedSet<string>
+            {
+                "4.0.0",
+                "4.5.0"
+            };
+            var packageVersionPair = new PackageVersionPair
+            {
+                PackageId = "System.DirectoryServices",
+                PackageSourceType = PackageSourceType.NUGET,
+                Version = "5.0.0"
+            };
+            var packageDetails = new PackageDetails
+            {
+                Name = "System.DirectoryServices",
+                Versions = versions,
+                Targets = new Dictionary<string, SortedSet<string>>
+                {
+                    { "net5.0",  versions }
+                }
+            };
+
+            var compatResults = PackageCompatibility.IsCompatibleAsync(Task.FromResult(packageDetails), packageVersionPair, NullLogger.Instance);
+
+            Assert.AreEqual(0, compatResults.Result.CompatibleVersions.Count);
+            Assert.AreEqual(Compatibility.INCOMPATIBLE, compatibilityResult.Compatibility);
+        }
     }
 }


### PR DESCRIPTION
#### Description of change
* Fix how compatibility is calculated for nuget packages that become incompatible with in a later version (e.g. System.DirectoryServices)
* If a packageId shares a name with an SDK namespace (e.g. System.DirectoryServices), don't analyze it as both a nuget and an SDK. Instead, only analyze it as a nuget.

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
