### PR TITLE
fix: use session token in metrics request

### DIFF
--- a/src/PortingAssistant.Client.Telemetry/Uploader.cs
+++ b/src/PortingAssistant.Client.Telemetry/Uploader.cs
@@ -170,6 +170,10 @@ namespace PortingAssistant.Client.Telemetry
                     };
 
                     request = await signer.Sign(request, "execute-api", region);
+                    if (!string.IsNullOrEmpty(awsCredentials.GetCredentials().Token))
+                    {
+                        request.Headers.Add("x-amz-security-token", awsCredentials.GetCredentials().Token);
+                    }
 
                     var response = await client.SendAsync(request);
 


### PR DESCRIPTION
#### Description of change
use session token for short term creds in metrics upload


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
