### PR TITLE
Update API and PackageCompatibility logic to support regressions in package compatibility

### DIFF
--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -83,12 +83,18 @@ namespace PortingAssistant.Client.Analysis
                     var nugetPackages = externalReferences?.NugetReferences?
                             .Select(r => CodeEntityModelToCodeEntities.ReferenceToPackageVersionPair(r))?
                             .ToHashSet();
+                    var nugetPackageNameLookup = nugetPackages.Select(package => package.PackageId).ToHashSet();
 
                     var subDependencies = externalReferences?.NugetDependencies?
                         .Select(r => CodeEntityModelToCodeEntities.ReferenceToPackageVersionPair(r))
                         .ToHashSet();
 
-                    var sdkPackages = namespaces.Select(n => new PackageVersionPair { PackageId = n, Version = "0.0.0", PackageSourceType = PackageSourceType.SDK });
+                    var sdkPackages = namespaces.Select(n => new PackageVersionPair
+                    {
+                        PackageId = n, 
+                        Version = "0.0.0", 
+                        PackageSourceType = PackageSourceType.SDK
+                    }).Where(pair => !nugetPackageNameLookup.Contains(pair.PackageId));
 
                     var allPackages = nugetPackages
                         .Union(subDependencies)

--- a/src/PortingAssistant.Client.Analysis/Utils/NugetVersionExtensions.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/NugetVersionExtensions.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NuGet.Versioning;
+
+namespace PortingAssistant.Client.Analysis.Utils
+{
+    public static class NugetVersionExtensions
+    {
+        private static readonly HashSet<string> ZeroVersions = new HashSet<string>
+        {
+            "0.0.0",
+            "0.0.0.0"
+        };
+
+        public static bool IsZeroVersion(this NuGetVersion thisVersion)
+        {
+            return ZeroVersions.Contains(thisVersion.ToString());
+        }
+
+        public static bool IsGreaterThanOrEqualTo(this NuGetVersion thisVersion, string otherVersion)
+        {
+            if (NuGetVersion.TryParse(otherVersion, out var validOtherVersion))
+            {
+
+                return validOtherVersion.IsZeroVersion() 
+                       || thisVersion.IsGreaterThanOrEqualTo(validOtherVersion);
+            }
+
+            return false;
+        }
+
+        public static bool IsGreaterThanOrEqualTo(this NuGetVersion thisVersion, NuGetVersion otherVersion)
+        {
+            return thisVersion.CompareTo(otherVersion) >= 0;
+        }
+
+        public static bool IsGreaterThan(this NuGetVersion thisVersion, string otherVersion)
+        {
+            if (otherVersion == "0.0.0" || otherVersion == "0.0.0.0")
+            {
+                return true;
+            }
+
+            if (NuGetVersion.TryParse(otherVersion, out var validOtherVersion))
+            {
+                return thisVersion.IsGreaterThan(validOtherVersion);
+            }
+
+            return false;
+        }
+
+        public static bool IsGreaterThan(this NuGetVersion thisVersion, NuGetVersion otherVersion)
+        {
+            return thisVersion.CompareTo(otherVersion) > 0;
+        }
+
+        public static bool IsLessThanOrEqualTo(this NuGetVersion thisVersion, string otherVersion)
+        {
+            if (thisVersion.ToString() == "0.0.0" || thisVersion.ToString() == "0.0.0.0")
+            {
+                return true;
+            }
+
+            if (NuGetVersion.TryParse(otherVersion, out var validOtherVersion))
+            {
+                return thisVersion.IsLessThanOrEqualTo(validOtherVersion);
+            }
+
+            return false;
+        }
+
+        public static bool IsLessThanOrEqualTo(this NuGetVersion thisVersion, NuGetVersion otherVersion)
+        {
+            return thisVersion.CompareTo(otherVersion) <= 0;
+        }
+
+        public static bool HasSameMajorAs(this NuGetVersion thisVersion, string otherVersion)
+        {
+            if (NuGetVersion.TryParse(otherVersion, out var validOtherVersion))
+            {
+                return thisVersion.HasSameMajorAs(validOtherVersion);
+            }
+
+            return false;
+        }
+
+        public static bool HasSameMajorAs(this NuGetVersion thisVersion, NuGetVersion otherVersion)
+        {
+            return thisVersion.Major.CompareTo(otherVersion.Major) == 0;
+        }
+
+        public static IEnumerable<string> FindLowerOrEqualCompatibleVersions(this NuGetVersion thisVersion, IEnumerable<string> compatibleNugetVersions)
+        {
+            return compatibleNugetVersions.Where(v =>
+            {
+                if (NuGetVersion.TryParse(v, out var validNugetVersion))
+                {
+                    return validNugetVersion.IsLessThanOrEqualTo(thisVersion);
+                }
+
+                return false;
+            });
+        }
+
+        public static bool HasLowerOrEqualCompatibleVersion(this NuGetVersion thisVersion, IEnumerable<string> compatibleNugetVersions)
+        {
+            return thisVersion.FindLowerOrEqualCompatibleVersions(compatibleNugetVersions).Any();
+        }
+
+        public static IEnumerable<string> FindGreaterCompatibleVersions(this NuGetVersion thisVersion, IEnumerable<string> compatibleNugetVersions)
+        {
+            return compatibleNugetVersions.Where(v =>
+            {
+                if (NuGetVersion.TryParse(v, out var validNugetVersion))
+                {
+                    return validNugetVersion.IsGreaterThan(thisVersion);
+                }
+
+                return false;
+            });
+        }
+    }
+}

--- a/src/PortingAssistant.Client.Analysis/Utils/NugetVersionHelper.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/NugetVersionHelper.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NuGet.Versioning;
+
+namespace PortingAssistant.Client.Analysis.Utils
+{
+    public class NugetVersionHelper
+    {
+        public static NuGetVersion GetMaxVersion(IEnumerable<string> nugetVersions)
+        {
+            var parsedVersions = nugetVersions.Select(v =>
+            {
+                if (NuGetVersion.TryParse(v, out var validVersion))
+                {
+                    return validVersion;
+                }
+
+                return null;
+            }).Where(v => v!= null);
+
+            // Returns null if there are no valid nugetVersions
+            return GetMaxVersion(parsedVersions);
+        }
+
+        public static NuGetVersion GetMaxVersion(IEnumerable<NuGetVersion> nugetVersions)
+        {
+            return nugetVersions.Max();
+        }
+        
+        public static bool HasLowerCompatibleVersionWithSameMajor(NuGetVersion nugetVersion, IEnumerable<string> compatibleNugetVersions)
+        {
+            return compatibleNugetVersions.Any(v =>
+                nugetVersion.IsGreaterThanOrEqualTo(v)
+                && nugetVersion.HasSameMajorAs(v)
+            );
+        }
+    }
+}

--- a/tests/PortingAssistant.Client.UnitTests/NugetVersionExtensionTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/NugetVersionExtensionTest.cs
@@ -1,0 +1,99 @@
+﻿using NuGet.Versioning;
+using NUnit.Framework;
+using PortingAssistant.Client.Analysis.Utils;
+using System.Collections.Generic;
+
+namespace PortingAssistant.Client.UnitTests
+{
+    public class NugetVersionExtensionTest
+    {
+        private NuGetVersion _nugetVersion;
+        private const string VersionToTest = "2.1.1";
+
+        private const string EqualVersion = "2.1.1";
+        private const string GreaterVersion = "2.1.2";
+        private const string LowerVersion = "2.1.0";
+
+        private const string GreaterMajorVersion = "3.1.1";
+        private const string LowerMajorVersion = "1.1.1";
+
+        private const string ZeroVersion1 = "0.0.0";
+        private const string ZeroVersion2 = "0.0.0.0";
+
+        [SetUp]
+        public void Setup()
+        {
+            _nugetVersion = NuGetVersion.Parse(VersionToTest);
+        }
+
+        [TestCase(EqualVersion, true)]
+        [TestCase(GreaterVersion, false)]
+        [TestCase(LowerVersion, true)]
+        public void IsGreaterThanOrEqualTo_Returns_Correct_Value(string versionToCompare, bool expectedResult)
+        {
+            var actualResult = _nugetVersion.IsGreaterThanOrEqualTo(versionToCompare);
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCase(ZeroVersion1, true)]
+        [TestCase(ZeroVersion2, true)]
+        [TestCase(VersionToTest, false)]
+        public void IsZeroVersion_Returns_Correct_Value(string version, bool expectedResult)
+        {
+            var nugetVersion = NuGetVersion.Parse(version);
+            var actualResult = nugetVersion.IsZeroVersion();
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCase(EqualVersion, false)]
+        [TestCase(GreaterVersion, false)]
+        [TestCase(LowerVersion, true)]
+        public void IsGreaterThan_Returns_Correct_Value(string versionToCompare, bool expectedResult)
+        {
+            var actualResult = _nugetVersion.IsGreaterThan(versionToCompare);
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCase(EqualVersion, true)]
+        [TestCase(GreaterVersion, true)]
+        [TestCase(LowerVersion, false)]
+        public void IsLessThanOrEqualTo_Returns_Correct_Value(string versionToCompare, bool expectedResult)
+        {
+            var actualResult = _nugetVersion.IsLessThanOrEqualTo(versionToCompare);
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCase(GreaterMajorVersion, false)]
+        [TestCase(LowerMajorVersion, false)]
+        [TestCase(GreaterVersion, true)]
+        [TestCase(LowerVersion, true)]
+        public void HasSameMajorAs_Returns_Correct_Value(string versionToCompare, bool expectedResult)
+        {
+            var actualResult = _nugetVersion.HasSameMajorAs(versionToCompare);
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public void FindGreaterCompatibleVersions_Returns_Greater_Versions()
+        {
+            var compatibleVersions = new List<string>
+            {
+                "1.9.0",
+                "2.1.0",
+                "2.1.1", 
+                "2.1.2", 
+                "2.1.4", 
+                "2.4.1"
+            };
+            var expectedResult = new List<string> 
+            {  
+                "2.1.2",
+                "2.1.4",
+                "2.4.1"
+            };
+
+            var actualResult = _nugetVersion.FindGreaterCompatibleVersions(compatibleVersions);
+            CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        }
+    }
+}

--- a/tests/PortingAssistant.Client.UnitTests/NugetVersionHelperTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/NugetVersionHelperTest.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using NuGet.Versioning;
+using NUnit.Framework;
+using PortingAssistant.Client.Analysis.Utils;
+
+namespace PortingAssistant.Client.UnitTests
+{
+    public class NugetVersionHelperTest
+    {
+        [Test]
+        public void GetMaxVersion_Returns_Largest_Version()
+        {
+            var expectedResult = NuGetVersion.Parse("3.0.0");
+            var actualResult = NugetVersionHelper.GetMaxVersion(new List<string>
+            {
+                "1.0.0",
+                "2.1.0",
+                "3.0.0",
+                "2.9.0"
+            });
+
+            Assert.AreEqual(expectedResult.ToString(), actualResult.ToString());
+        }
+
+        [Test]
+        public void GetMaxVersion_Returns_Null_When_Input_Is_Empty()
+        {
+            var actualResult = NugetVersionHelper.GetMaxVersion(new List<string>());
+            Assert.IsNull(actualResult);
+        }
+
+        [Test]
+        public void HasLowerCompatibleVersionWithSameMajor_Returns_True_With_LowerCompatibleVersionWithSameMajor()
+        {
+            var nugetVersion = NuGetVersion.Parse("3.1.0");
+            var actualResult = NugetVersionHelper.HasLowerCompatibleVersionWithSameMajor(nugetVersion, new List<string>
+            {
+                "3.0.0"
+            });
+            Assert.IsTrue(actualResult);
+        }
+
+        [Test]
+        public void HasLowerCompatibleVersionWithSameMajor_Returns_False_Without_LowerCompatibleVersionWithSameMajor()
+        {
+            var nugetVersion = NuGetVersion.Parse("3.1.0");
+            var actualResult = NugetVersionHelper.HasLowerCompatibleVersionWithSameMajor(nugetVersion, new List<string>
+            {
+                "2.9.0",
+                "3.2.0"
+            });
+            Assert.IsFalse(actualResult);
+        }
+    }
+}


### PR DESCRIPTION
Closes: #1035

## Description
* Starting with .NET 5, attributes indicating platform support was made public. This enabled us to properly detect some packages as INCOMPATIBLE once they targeted .NET 5. It also created new compatibility analysis edge cases where packages can be labeled as COMPATIBLE in some versions and labeled as INCOMPATIBLE in later versions.
* Below are the changes in compatibility logic:

## Original Logic
* If the current package/api version is greater than any compatible version of that package/api, mark it as COMPATIBLE
* This assumes that once a package became compatible with some version X, it would remain compatible for all versions > X
* It also gave us a best guess for compatibility for the most recent package versions that may not have been analyzed and stored in our datastore yet

## New Logic
* If the current package/api version is greater than any compatible version with the same major, mark it as COMPATIBLE. Otherwise, mark it as INCOMPATIBLE.
* In all other cases, use the previous logic of: If the current package/api version is greater than any compatible version of that package/api, mark it as COMPATIBLE
* This preserves the essence and benefits of the original logic except in cases where a new major version caused a change in compatibility (e.g. Microsoft.DirectoryServices)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
