### PR TITLE
Bugfix/p59216288 duplicated aggregate exception

### DIFF
--- a/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
@@ -122,19 +122,6 @@ namespace PortingAssistant.Client.Analysis.Utils
                     CompatibleVersions = new List<string>()
                 };
             }
-
-            catch (AggregateException ae)
-            {
-                foreach (var e in ae.Flatten().InnerExceptions)
-                {
-                    _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);
-                }
-                return new CompatibilityResult
-                {
-                    Compatibility = Compatibility.UNKNOWN,
-                    CompatibleVersions = new List<string>()
-                };
-            }
             catch (Exception e)
             {
                 _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);

--- a/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
@@ -122,6 +122,22 @@ namespace PortingAssistant.Client.Analysis.Utils
                     CompatibleVersions = new List<string>()
                 };
             }
+
+            catch (AggregateException ae)
+            {
+                foreach (var e in ae.Flatten().InnerExceptions)
+                {
+                    if (!(e is PortingAssistantClientException))
+                    {
+                        _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);
+                    }
+                }
+                return new CompatibilityResult
+                {
+                    Compatibility = Compatibility.UNKNOWN,
+                    CompatibleVersions = new List<string>()
+                };
+            }
             catch (Exception e)
             {
                 _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);

--- a/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
+++ b/src/PortingAssistant.Client.Analysis/Utils/PackageCompatibility.cs
@@ -127,10 +127,7 @@ namespace PortingAssistant.Client.Analysis.Utils
             {
                 foreach (var e in ae.Flatten().InnerExceptions)
                 {
-                    if (!(e is PortingAssistantClientException))
-                    {
-                        _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);
-                    }
+                    _logger.LogError("parse package version {0} {1} with error {2}", packageVersionPair.PackageId, packageVersionPair.Version, e);
                 }
                 return new CompatibilityResult
                 {

--- a/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
+++ b/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
@@ -86,7 +86,7 @@ namespace PortingAssistant.Client.NuGet
                                 }
                             }
                             else
-                            {
+                            {  
                                 exceptions.TryAdd(result.Key, task.Exception);
                             }
                         });
@@ -102,8 +102,7 @@ namespace PortingAssistant.Client.NuGet
             {
                 if (packageVersion != null && _compatibilityTaskCompletionSources.TryGetValue(packageVersion, out var packageVersionPairResult))
                 {
-                    _logger.LogError($"Cound not find package {packageVersion} in all sources");
-                    var defaultErrorMessage = $"Could not find package {packageVersion}. Compatibility task status: {packageVersionPairResult.Task.Status}.";
+                    var defaultErrorMessage = $"Could not find package {packageVersion} in all sources. Compatibility task status: {packageVersionPairResult.Task.Status}.";
                     var defaultException = new PortingAssistantClientException(ExceptionMessage.PackageNotFound(packageVersion), new PackageNotFoundException(defaultErrorMessage));
                     var exception = exceptions.GetValueOrDefault(packageVersion, defaultException);
 

--- a/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
+++ b/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
@@ -102,7 +102,6 @@ namespace PortingAssistant.Client.NuGet
             {
                 if (packageVersion != null && _compatibilityTaskCompletionSources.TryGetValue(packageVersion, out var packageVersionPairResult))
                 {
-                    _logger.LogError($"Cound not find package {packageVersion} in all sources");
                     var defaultErrorMessage = $"Could not find package {packageVersion} in all sources. Compatibility task status: {packageVersionPairResult.Task.Status}.";
                     var defaultException = new PortingAssistantClientException(ExceptionMessage.PackageNotFound(packageVersion), new PackageNotFoundException(defaultErrorMessage));
                     var exception = exceptions.GetValueOrDefault(packageVersion, defaultException);

--- a/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
+++ b/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
@@ -102,6 +102,7 @@ namespace PortingAssistant.Client.NuGet
             {
                 if (packageVersion != null && _compatibilityTaskCompletionSources.TryGetValue(packageVersion, out var packageVersionPairResult))
                 {
+                    _logger.LogError($"Cound not find package {packageVersion} in all sources");
                     var defaultErrorMessage = $"Could not find package {packageVersion} in all sources. Compatibility task status: {packageVersionPairResult.Task.Status}.";
                     var defaultException = new PortingAssistantClientException(ExceptionMessage.PackageNotFound(packageVersion), new PackageNotFoundException(defaultErrorMessage));
                     var exception = exceptions.GetValueOrDefault(packageVersion, defaultException);

--- a/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
+++ b/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
@@ -110,7 +110,8 @@ namespace PortingAssistant.Client.NuGet
                             (exception.InnerException is PortingAssistantClientException) ? null: exception.InnerException);
                         packageVersionPairResult.TrySetException(newException);
                     }
-                    else {
+                    else 
+                    {
                         var defaultException = new PortingAssistantClientException(ExceptionMessage.PackageNotFound(packageVersion), new PackageNotFoundException(defaultErrorMessage));
                         packageVersionPairResult.TrySetException(defaultException);
                     }

--- a/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
+++ b/src/PortingAssistant.Client.NuGet/PortingAssistantNuGetHandler.cs
@@ -103,10 +103,17 @@ namespace PortingAssistant.Client.NuGet
                 if (packageVersion != null && _compatibilityTaskCompletionSources.TryGetValue(packageVersion, out var packageVersionPairResult))
                 {
                     var defaultErrorMessage = $"Could not find package {packageVersion} in all sources. Compatibility task status: {packageVersionPairResult.Task.Status}.";
-                    var defaultException = new PortingAssistantClientException(ExceptionMessage.PackageNotFound(packageVersion), new PackageNotFoundException(defaultErrorMessage));
-                    var exception = exceptions.GetValueOrDefault(packageVersion, defaultException);
-
-                    packageVersionPairResult.TrySetException(exception);
+                    
+                    if (exceptions.TryGetValue(packageVersion, out var exception))
+                    {
+                        var newException = new PortingAssistantClientException(defaultErrorMessage, 
+                            (exception.InnerException is PortingAssistantClientException) ? null: exception.InnerException);
+                        packageVersionPairResult.TrySetException(newException);
+                    }
+                    else {
+                        var defaultException = new PortingAssistantClientException(ExceptionMessage.PackageNotFound(packageVersion), new PackageNotFoundException(defaultErrorMessage));
+                        packageVersionPairResult.TrySetException(defaultException);
+                    }
                 }
                 else
                 {

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -730,7 +730,7 @@ namespace PortingAssistant.Client.Tests
         public void CompatibilityCheckOfMissingExternalPackageThrowsException()
         {
             SetMockHttpService(new PackageDetails());
-            var handler = GetCheckerWithException();
+
             var externalPackagesCompatibilityChecker = GetExternalPackagesCompatibilityChecker();
 
             var packageVersionPair = new PackageVersionPair { PackageId = "Newtonsoft.Json", Version = "12.0.5", PackageSourceType = PackageSourceType.NUGET };

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -730,7 +730,7 @@ namespace PortingAssistant.Client.Tests
         public void CompatibilityCheckOfMissingExternalPackageThrowsException()
         {
             SetMockHttpService(new PackageDetails());
-
+            var handler = GetCheckerWithException();
             var externalPackagesCompatibilityChecker = GetExternalPackagesCompatibilityChecker();
 
             var packageVersionPair = new PackageVersionPair { PackageId = "Newtonsoft.Json", Version = "12.0.5", PackageSourceType = PackageSourceType.NUGET };
@@ -741,17 +741,11 @@ namespace PortingAssistant.Client.Tests
 
             var resultTasks = externalPackagesCompatibilityChecker.Check(packages, null);
 
-            _loggerMock.Verify(_ => _.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsValueType>(),
-                It.IsAny<Exception>(),
-                (Func<It.IsValueType, Exception, string>)It.IsAny<object>()), Times.Exactly(2));
-
             Assert.Throws<AggregateException>(() =>
             {
                 Task.WaitAll(resultTasks.Values.ToArray());
             });
+
         }
 
         [Test]
@@ -768,7 +762,7 @@ namespace PortingAssistant.Client.Tests
                 It.IsAny<EventId>(),
                 It.IsAny<It.IsValueType>(),
                 It.IsAny<Exception>(),
-                (Func<It.IsValueType, Exception, string>)It.IsAny<object>()), Times.Exactly(2));
+                (Func<It.IsValueType, Exception, string>)It.IsAny<object>()), Times.Exactly(1));
         }
 
         [Test]
@@ -810,7 +804,7 @@ namespace PortingAssistant.Client.Tests
                 It.IsAny<EventId>(),
                 It.IsAny<It.IsValueType>(),
                 It.IsAny<Exception>(),
-                (Func<It.IsValueType, Exception, string>)It.IsAny<object>()), Times.Exactly(2));
+                (Func<It.IsValueType, Exception, string>)It.IsAny<object>()), Times.Exactly(1));
         }
 
         [Test]

--- a/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Net;
 using Newtonsoft.Json;
 using Amazon.Runtime;
+using System.Text;
 
 namespace PortingAssistant.Client.UnitTests
 {
@@ -64,8 +65,20 @@ namespace PortingAssistant.Client.UnitTests
             var logFilePath = Path.Combine(logs, "portingAssistant-client-cli-test-2.log");
             var metricsFilePath = Path.Combine(logs, "portingAssistant-client-cli-test-2.metrics");
 
-            File.WriteAllLines(logFilePath, logLines);
-            File.WriteAllLines(metricsFilePath, metricLogLines);
+            using (TextWriter tw = new StreamWriter(logFilePath))
+            {
+                foreach (String s in logLines)
+                    tw.WriteLine(s);
+            }
+            using (TextWriter tw = new StreamWriter(metricsFilePath))
+            {
+                foreach (String s in metricLogLines)
+                    tw.WriteLine(s);
+            }
+
+            //The following two lines throw  System.IO.DirectoryNotFoundException sometimes
+            //File.WriteAllLines(logFilePath, logLines);
+            //File.WriteAllLines(metricsFilePath, metricLogLines);
 
             var teleConfig = new TelemetryConfiguration
             {

--- a/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
@@ -65,20 +65,13 @@ namespace PortingAssistant.Client.UnitTests
             var logFilePath = Path.Combine(logs, "portingAssistant-client-cli-test-2.log");
             var metricsFilePath = Path.Combine(logs, "portingAssistant-client-cli-test-2.metrics");
 
-            using (TextWriter tw = new StreamWriter(logFilePath))
+            if (!Directory.Exists(logs))
             {
-                foreach (String s in logLines)
-                    tw.WriteLine(s);
-            }
-            using (TextWriter tw = new StreamWriter(metricsFilePath))
-            {
-                foreach (String s in metricLogLines)
-                    tw.WriteLine(s);
+                DirectoryInfo di = Directory.CreateDirectory(logs);
             }
 
-            //The following two lines throw  System.IO.DirectoryNotFoundException sometimes
-            //File.WriteAllLines(logFilePath, logLines);
-            //File.WriteAllLines(metricsFilePath, metricLogLines);
+            File.WriteAllLines(logFilePath, logLines);
+            File.WriteAllLines(metricsFilePath, metricLogLines);
 
             var teleConfig = new TelemetryConfiguration
             {


### PR DESCRIPTION
#### Description of change
[//]: Additional System.AggregateException will not be logged. 

New log file only shows.
"2022-02-16T15:04:49.0276837-08:00	FAIL	[PortingAssistant.Client.NuGet.PortingAssistantNuGetHandler]	[0]	Cound not find package [PackageNameXXX-version]-NUGET in all sources"

#### Issue
[//]: # AggregateException logged twice.  E.g. 

"[2022-01-28 16:15:51 ERR] (1.6.4) PortingAssistant.Client.NuGet.PortingAssistantNuGetHandler: Cound not find package Simple.Internet-4.4.3-NUGET in all sources",
	"[2022-01-28 16:15:51 ERR] (1.6.4) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: parse package version Simple.Internet 4.4.3 with error System.AggregateException: One or more errors occurred. (Cannot find package Simple.Internet-4.4.3-NUGET)",

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
