### PR TITLE
set dependabot to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,6 @@ updates:
       - nuget-org
     schedule:
       interval: "weekly"
-    ignore:
-      # Starting with version 16.10.0, MSBuild requires .NET 5.0+
-      - dependency-name: "Microsoft.Build"
   - package-ecosystem: "nuget"
     directory: "/src/PortingAssistant.Client.Common"
     registries:
@@ -59,9 +56,6 @@ updates:
       - nuget-org
     schedule:
       interval: "weekly"
-    ignore:
-      # Starting with version 16.10.0, MSBuild requires .NET 5.0+
-      - dependency-name: "Microsoft.Build"
   - package-ecosystem: "nuget"
     directory: "/tests/PortingAssistant.Client.IntegrationTests"
     registries:
@@ -69,9 +63,6 @@ updates:
       - nuget-org
     schedule:
       interval: "weekly"
-    ignore:
-      # Starting with version 16.10.0, MSBuild requires .NET 5.0+
-      - dependency-name: "Microsoft.Build"
   - package-ecosystem: "nuget"
     directory: "/tests/PortingAssistant.Client.UnitTests"
     registries:
@@ -79,6 +70,3 @@ updates:
       - nuget-org
     schedule:
       interval: "weekly"
-    ignore:
-      # Starting with version 16.10.0, MSBuild requires .NET 5.0+
-      - dependency-name: "Microsoft.Build"


### PR DESCRIPTION
## Description
* Set dependabot to check for package updates on a weekly basis (checks on Monday by default)

---
*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
