### PR TITLE
feat: roll telemetry files daily

### DIFF
--- a/src/PortingAssistant.Client.Telemetry/Uploader.cs
+++ b/src/PortingAssistant.Client.Telemetry/Uploader.cs
@@ -23,10 +23,12 @@ namespace PortingAssistant.Client.Telemetry
         {
             try
             {
-                var fileEntries = new List<string> {
-                    teleConfig.LogFilePath,
-                    teleConfig.MetricsFilePath
-                }.Where(x => !string.IsNullOrEmpty(x) && File.Exists(x)).ToList();
+                var fileEntries = Directory.GetFiles(teleConfig.LogsPath)
+                    .Where(f =>
+                        Path.GetFileName(f)
+                            .StartsWith("portingAssistant-client-cli") &&
+                        teleConfig.Suffix.ToArray().Any(x => f.EndsWith(x))
+                    ).ToList();
 
                 var lastReadTokenFile = Path.Combine(teleConfig.LogsPath, "lastToken.json");
                 var fileLineNumberMap = new Dictionary<string, int>();

--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -35,8 +35,8 @@ namespace PortingAssistant.Client.CLI
             var configuration = new PortingAssistantConfiguration();
             var roamingFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             var logs = Path.Combine(roamingFolder, "Porting Assistant for .NET", "logs");
-            var logFilePath = Path.Combine(logs, "portingAssistant-client-cli.log");
-            var metricsFilePath = Path.Combine(logs, "portingAssistant-client-cli.metrics");
+            var logFilePath = Path.Combine(logs, "portingAssistant-client-cli-.log");
+            var metricsFilePath = Path.Combine(logs, $"portingAssistant-client-cli-{DateTime.Today:yyyyMMdd}.metrics");
 
             var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
 
@@ -47,7 +47,7 @@ namespace PortingAssistant.Client.CLI
 
             logConfiguration.WriteTo.File(
                     logFilePath,
-                    rollingInterval: RollingInterval.Infinite,
+                    rollingInterval: RollingInterval.Day,
                     rollOnFileSizeLimit: false,
                     outputTemplate: outputTemplate);
             Log.Logger = logConfiguration.CreateLogger();
@@ -150,6 +150,7 @@ namespace PortingAssistant.Client.CLI
                 telemetryConfiguration.LogFilePath = logFilePath;
                 telemetryConfiguration.MetricsFilePath = metricsFilePath;
                 telemetryConfiguration.LogsPath = logsPath;
+                telemetryConfiguration.Suffix = new List<string> {".log", ".metrics"};
 
                 if (TelemetryClientFactory.TryGetClient(profile, telemetryConfiguration, out ITelemetryClient client))
                 {

--- a/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
@@ -34,6 +34,7 @@ namespace PortingAssistant.Client.UnitTests
                 Description = "Test",
                 LogFilePath = Path.Combine(logs, "portingAssistant-client-cli-test.log"),
                 MetricsFilePath = Path.Combine(logs, "portingAssistant-client-cli-test.metrics"),
+                Suffix = new List<string> { ".log", ".metrics" }
             };
             bool actualSuccessStatus = false;
             if (TelemetryClientFactory.TryGetClient(profile, teleConfig, out ITelemetryClient client))
@@ -82,6 +83,7 @@ namespace PortingAssistant.Client.UnitTests
                 Description = "Test",
                 LogFilePath = logFilePath,
                 MetricsFilePath = metricsFilePath,
+                Suffix = new List<string> { ".log", ".metrics" }
             };
             var lastReadTokenFile = Path.Combine(teleConfig.LogsPath, "lastToken.json");
             bool result = Uploader.Upload(teleConfig, profile, telemetryClientMock.Object);


### PR DESCRIPTION
#### Description of change
Roll telemetry files everyday to prevent the logs/metrics files from becoming too large

#### Testing
Tested locally by running CLI and verifying correct files were being created, then manually adjusted time to next day to verify new files were being created. Verified that unit tests were still passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
