### PR TITLE
fix: add upload result and add null check for telemetry client

### DIFF
--- a/src/PortingAssistant.Client.Telemetry/Uploader.cs
+++ b/src/PortingAssistant.Client.Telemetry/Uploader.cs
@@ -49,12 +49,13 @@ namespace PortingAssistant.Client.Telemetry
         {
             try
             {
-                if (_shareMetrics)
+                bool uploadResult = true;
+                if (_shareMetrics && _client != null)
                 {
-                    Upload();
+                    uploadResult = Upload();
                 }
                 CleanupLogFolder();
-                return true;
+                return uploadResult;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
#### Description of change
Pass back the upload result if upload is attempted, gives caller more information on if upload was successful. 
Also add null checking for a null telemetry client, the telemetry client factory will return a null client if the AWS credentials are no longer valid, but we still want to run through the log clean up function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
