### PR TITLE
fix: profile string is null

### DIFF
--- a/src/PortingAssistant.Client.Telemetry/TelemetryClient.cs
+++ b/src/PortingAssistant.Client.Telemetry/TelemetryClient.cs
@@ -43,8 +43,9 @@ namespace PortingAssistant.Client.Telemetry
     public static class TelemetryClientFactory
     {
         public static bool TryGetClient(string profile, TelemetryConfiguration config, out ITelemetryClient client, bool enabledDefaultCredentials = false)
-        {
+        {   
             client = null;
+            if (string.IsNullOrEmpty(profile)) { return false; }
             var chain = new CredentialProfileStoreChain();
             AWSCredentials awsCredentials;
             if (enabledDefaultCredentials)

--- a/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/UploaderTest.cs
@@ -71,7 +71,7 @@ namespace PortingAssistant.Client.UnitTests
         {
             var telemetryClientMock = new Mock<ITelemetryClient>();
 
-            
+
             telemetryClientMock
                 .Setup(
                     x => x.SendAsync(It.IsAny<TelemetryRequest>()).Result
@@ -134,7 +134,23 @@ namespace PortingAssistant.Client.UnitTests
             "[2021 - 12 - 08 11:52:02 INF](Porting Assistant Client CLI)(1.11.19 - alpha + a0d7b74f85)(client) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: Current process is 64bit.",
             "[2021 - 12 - 08 11:52:02 INF](Porting Assistant Client CLI)(1.11.19 - alpha + a0d7b74f85)(client) PortingAssistant.Client.Analysis.PortingAssistantAnalysisHandler: Total size for C:\\Users\\longachr\\AppData\\Local\\Temp\\u03lvutv.1mn\\NetFrameworkExample\\NetFrameworkExample.sln in bytes: 4673"
         };
-    }
 
-    
+        [Test]
+        public void TestBlankProfilePassedIntoFactory()
+        {
+            var teleConfig = new TelemetryConfiguration();
+            bool actualSuccessStatus = TelemetryClientFactory.TryGetClient("", teleConfig, out ITelemetryClient client);
+            Assert.IsFalse(actualSuccessStatus);
+            Assert.IsNull(client);
+        }
+
+        [Test]
+        public void TestNullProfilePassedIntoFactory()
+        {
+            var teleConfig = new TelemetryConfiguration();
+            bool actualSuccessStatus = TelemetryClientFactory.TryGetClient(null, teleConfig, out ITelemetryClient client);
+            Assert.IsFalse(actualSuccessStatus);
+            Assert.IsNull(client);
+        }
+    }
 }


### PR DESCRIPTION
#### Description of change
- when trying to get telemetry client, add check if profile is blank or null to avoid errors in the credentials chain fetcher.
- add two unit test to verify functionality.

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
