### PR TITLE
fix: log upload message with no profile

### DIFF
--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -144,6 +144,10 @@ namespace PortingAssistant.Client.CLI
 
         private static void UploadLogs(string profile, TelemetryConfiguration telemetryConfiguration, string logFilePath, string metricsFilePath, string logsPath, bool enabledDefaultCredentials = false)
         {
+            if (string.IsNullOrEmpty(profile))
+            {
+                return;
+            }
             telemetryConfiguration.LogFilePath = logFilePath;
             telemetryConfiguration.MetricsFilePath = metricsFilePath;
             telemetryConfiguration.LogsPath = logsPath;


### PR DESCRIPTION
fix trying to upload logs when no profile is provided, this will prevent confusing error to be logged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
