### PR TITLE
[WIP] fix: add a filter to limit projects to just csharp or vb [WIP] 

### DIFF
--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -172,12 +172,21 @@ namespace PortingAssistant.Client.Client
         private List<string> ProjectsToAnalyze(string solutionFilePath, AnalyzerSettings settings)
         {
             var solution = SolutionFile.Parse(solutionFilePath);
-            return solution.ProjectsInOrder.Where(p =>
-                (p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat ||
-                p.ProjectType == SolutionProjectType.WebProject) &&
-                (settings.IgnoreProjects?.Contains(p.AbsolutePath) != true))
-                .Select(p => p.AbsolutePath)
-                .ToList();
+            return 
+                solution
+                    .ProjectsInOrder
+                        // is a MSBuild or Web Project
+                    .Where(p => (p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat || p.ProjectType == SolutionProjectType.WebProject))
+                        // hasn't been ignored
+                    .Where(p => (settings.IgnoreProjects?.Contains(p.AbsolutePath) != true))
+                        // is VB or C# project
+                    .Where(p =>
+                    {
+                        var projectFileExtension = Path.GetExtension(p.AbsolutePath ?? "").ToLower();
+                        return projectFileExtension == ".csproj" || projectFileExtension == ".vbproj";
+                    })
+                    .Select(p => p.AbsolutePath)
+                    .ToList();
         }
     }
 }


### PR DESCRIPTION
#### Description of change
[//]: # (What are you trying to fix? What did you change)
Limit the project types to be analyzed to just be C# or VB.

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)
If a solution contains a C++ project or other project type other than C#/VB it can cause Porting Assistant to crash

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)

**WIP**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
