### PR TITLE
fix: add visualstudio version as parameter for assessment and porting

### DIFF
--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -40,7 +40,7 @@ namespace PortingAssistant.Client.Analysis
         private async Task<List<AnalyzerResult>> RunCoderlyzerAnalysis(string solutionFilename, List<string> projects, AnalyzerSettings analyzerSettings = null)
         {
             MemoryUtils.LogSystemInfo(_logger);
-            MemoryUtils.LogSolutiontSize(_logger, solutionFilename);
+            MemoryUtils.LogSolutionSize(_logger, solutionFilename);
             _logger.LogInformation("Memory usage before RunCoderlyzerAnalysis: ");
             MemoryUtils.LogMemoryConsumption(_logger);
 

--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -410,7 +410,7 @@ namespace PortingAssistant.Client.Analysis
 
                 configs.Add(projectConfiguration);
             }
-            var solutionPort = new SolutionPort(pathToSolution, analyzerResults, configs, _logger, analyzerSettings?.VisualStudioVersion.ToString());
+            var solutionPort = new SolutionPort(pathToSolution, analyzerResults, configs, _logger);
             var projectResults = solutionPort.Run().ProjectResults.ToList();
 
             TraceEvent.End(_logger, $"Analyzing solution for applicable porting actions: {pathToSolution}");

--- a/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/AnalysisHandler.cs
@@ -29,7 +29,7 @@ namespace PortingAssistant.Client.Analysis
 
         public PortingAssistantAnalysisHandler(
             ILogger<PortingAssistantAnalysisHandler> logger,
-            IPortingAssistantNuGetHandler handler, 
+            IPortingAssistantNuGetHandler handler,
             IPortingAssistantRecommendationHandler recommendationHandler)
         {
             _logger = logger;
@@ -37,14 +37,14 @@ namespace PortingAssistant.Client.Analysis
             _recommendationHandler = recommendationHandler;
         }
 
-        private async Task<List<AnalyzerResult>> RunCoderlyzerAnalysis(string solutionFilename, List<string> projects)
+        private async Task<List<AnalyzerResult>> RunCoderlyzerAnalysis(string solutionFilename, List<string> projects, AnalyzerSettings analyzerSettings = null)
         {
             MemoryUtils.LogSystemInfo(_logger);
             MemoryUtils.LogSolutiontSize(_logger, solutionFilename);
             _logger.LogInformation("Memory usage before RunCoderlyzerAnalysis: ");
             MemoryUtils.LogMemoryConsumption(_logger);
 
-            var configuration = GetAnalyzerConfiguration(projects);
+            var configuration = GetAnalyzerConfiguration(projects, analyzerSettings);
             CodeAnalyzerByLanguage analyzer = new CodeAnalyzerByLanguage(configuration, _logger);
 
             TraceEvent.Start(_logger, $"Codelyzer analysis: {solutionFilename}");
@@ -58,16 +58,16 @@ namespace PortingAssistant.Client.Analysis
         }
 
         public async Task<List<SourceFileAnalysisResult>> AnalyzeFileIncremental(
-            string filePath, 
-            string fileContent, 
-            string projectFile, 
-            string solutionFilePath, 
-            List<string> preportReferences, 
-            List<string> currentReferences, 
-            RootNodes projectRules, 
-            ExternalReferences externalReferences, 
+            string filePath,
+            string fileContent,
+            string projectFile,
+            string solutionFilePath,
+            List<string> preportReferences,
+            List<string> currentReferences,
+            RootNodes projectRules,
+            ExternalReferences externalReferences,
             bool actionsOnly = false,
-            bool compatibleOnly = false, 
+            bool compatibleOnly = false,
             string targetFramework = DEFAULT_TARGET)
         {
             try
@@ -110,7 +110,7 @@ namespace PortingAssistant.Client.Analysis
                         .Select(r => CodeEntityModelToCodeEntities.ReferenceToPackageVersionPair(r))
                         .ToHashSet();
 
-                    var sdkPackages = namespaces.Select(n => 
+                    var sdkPackages = namespaces.Select(n =>
                             new PackageVersionPair
                             {
                                 PackageId = n,
@@ -176,15 +176,15 @@ namespace PortingAssistant.Client.Analysis
         }
 
         public async Task<List<SourceFileAnalysisResult>> AnalyzeFileIncremental(
-            string filePath, 
-            string projectFile, 
-            string solutionFilePath, 
-            List<string> preportReferences, 
-            List<string> currentReferences, 
-            RootNodes projectRules, 
-            ExternalReferences externalReferences, 
-            bool actionsOnly, 
-            bool compatibleOnly, 
+            string filePath,
+            string projectFile,
+            string solutionFilePath,
+            List<string> preportReferences,
+            List<string> currentReferences,
+            RootNodes projectRules,
+            ExternalReferences externalReferences,
+            bool actionsOnly,
+            bool compatibleOnly,
             string targetFramework = DEFAULT_TARGET)
         {
             var fileContent = File.ReadAllText(filePath);
@@ -192,16 +192,17 @@ namespace PortingAssistant.Client.Analysis
         }
 
         public async Task<Dictionary<string, ProjectAnalysisResult>> AnalyzeSolutionIncremental(
-            string solutionFilename, 
-            List<string> projects, 
-            string targetFramework = DEFAULT_TARGET)
+            string solutionFilename,
+            List<string> projects,
+            string targetFramework = DEFAULT_TARGET,
+            AnalyzerSettings analyzerSettings = null)
         {
             try
             {
                 TraceEvent.Start(_logger, $"Incremental solution assessment: {solutionFilename}");
-                var analyzerResults = await RunCoderlyzerAnalysis(solutionFilename, projects);
+                var analyzerResults = await RunCoderlyzerAnalysis(solutionFilename, projects, analyzerSettings);
 
-                var analysisActions = AnalyzeActions(projects, targetFramework, analyzerResults, solutionFilename);
+                var analysisActions = AnalyzeActions(projects, targetFramework, analyzerResults, solutionFilename, analyzerSettings);
 
                 var solutionAnalysisResult = AnalyzeProjects(
                     solutionFilename, projects,
@@ -230,11 +231,11 @@ namespace PortingAssistant.Client.Analysis
         }
 
         private List<IDEFileActions> AnalyzeFileActionsIncremental(
-            string project, 
+            string project,
             RootNodes rootNodes,
-            string targetFramework, 
-            string pathToSolution, 
-            string filePath, 
+            string targetFramework,
+            string pathToSolution,
+            string filePath,
             IDEProjectResult projectResult)
         {
             TraceEvent.Start(_logger, $"Incremental file action analysis: {filePath}");
@@ -258,13 +259,13 @@ namespace PortingAssistant.Client.Analysis
             return solutionPort.RunIncremental(rootNodes, filePath);
         }
 
-        #nullable enable
+#nullable enable
         private async Task<IDEProjectResult?> AnalyzeProjectFiles(
             string projectPath,
-			string fileContent,
-			string filePath,
-			List<string> preportReferences,
-			List<string> currentReferences)
+            string fileContent,
+            string filePath,
+            List<string> preportReferences,
+            List<string> currentReferences)
         {
             try
             {
@@ -298,19 +299,20 @@ namespace PortingAssistant.Client.Analysis
             }
             return null;
         }
-        #nullable disable
+#nullable disable
 
         public async Task<Dictionary<string, ProjectAnalysisResult>> AnalyzeSolution(
             string solutionFilename,
-			List<string> projects,
-			string targetFramework = DEFAULT_TARGET)
+            List<string> projects,
+            string targetFramework = DEFAULT_TARGET,
+            AnalyzerSettings analyzerSettings = null)
         {
             try
             {
                 TraceEvent.Start(_logger, $"Compatibility assessment of solution without generator: {solutionFilename}");
-                var analyzerResults = await RunCoderlyzerAnalysis(solutionFilename, projects);
+                var analyzerResults = await RunCoderlyzerAnalysis(solutionFilename, projects, analyzerSettings);
 
-                var analysisActions = AnalyzeActions(projects, targetFramework, analyzerResults, solutionFilename);
+                var analysisActions = AnalyzeActions(projects, targetFramework, analyzerResults, solutionFilename, analyzerSettings);
 
                 var solutionAnalysisResult = AnalyzeProjects(
                     solutionFilename, projects,
@@ -335,8 +337,8 @@ namespace PortingAssistant.Client.Analysis
 
         public async IAsyncEnumerable<ProjectAnalysisResult> AnalyzeSolutionGeneratorAsync(
             string solutionFilename,
-			List<string> projects,
-			string targetFramework = "net6.0")
+            List<string> projects,
+            string targetFramework = "net6.0")
         {
             var configuration = GetAnalyzerConfiguration(projects);
             var analyzer = new CodeAnalyzerByLanguage(configuration, _logger);
@@ -350,7 +352,7 @@ namespace PortingAssistant.Client.Analysis
                 {
                     var result = resultEnumerator.Current;
                     var projectPath = result?.ProjectResult?.ProjectFilePath;
-                    
+
                     var projectConfiguration = new PortCoreConfiguration
                     {
                         ProjectPath = projectPath,
@@ -378,9 +380,9 @@ namespace PortingAssistant.Client.Analysis
 
         private List<ProjectResult> AnalyzeActions(
             List<string> projects,
-			string targetFramework,
-			List<AnalyzerResult> analyzerResults,
-			string pathToSolution)
+            string targetFramework,
+            List<AnalyzerResult> analyzerResults,
+            string pathToSolution, AnalyzerSettings analyzerSettings = null)
         {
             TraceEvent.Start(_logger, $"Analyzing solution for applicable porting actions: {pathToSolution}");
             _logger.LogInformation("Memory Consumption before AnalyzeActions: ");
@@ -408,7 +410,7 @@ namespace PortingAssistant.Client.Analysis
 
                 configs.Add(projectConfiguration);
             }
-            var solutionPort = new SolutionPort(pathToSolution, analyzerResults, configs, _logger);
+            var solutionPort = new SolutionPort(pathToSolution, analyzerResults, configs, _logger, analyzerSettings?.VisualStudioVersion.ToString());
             var projectResults = solutionPort.Run().ProjectResults.ToList();
 
             TraceEvent.End(_logger, $"Analyzing solution for applicable porting actions: {pathToSolution}");
@@ -464,11 +466,11 @@ namespace PortingAssistant.Client.Analysis
 
         private ProjectAnalysisResult AnalyzeProject(
             string project,
-			string solutionFileName,
-			List<AnalyzerResult> analyzers,
-			List<ProjectResult> analysisActions,
-			bool isIncremental = false,
-			string targetFramework = DEFAULT_TARGET)
+            string solutionFileName,
+            List<AnalyzerResult> analyzers,
+            List<ProjectResult> analysisActions,
+            bool isIncremental = false,
+            string targetFramework = DEFAULT_TARGET)
         {
             try
             {
@@ -514,11 +516,11 @@ namespace PortingAssistant.Client.Analysis
                     .ToHashSet();
 
                 var sdkPackages = namespaces.Select(n => new PackageVersionPair
-                    {
-                        PackageId = n,
-                        Version = "0.0.0",
-                        PackageSourceType = PackageSourceType.SDK
-                    })
+                {
+                    PackageId = n,
+                    Version = "0.0.0",
+                    PackageSourceType = PackageSourceType.SDK
+                })
                     .Where(pair =>
                         !string.IsNullOrEmpty(pair.PackageId) &&
                         !nugetPackageNameLookup.Contains(pair.PackageId));
@@ -596,17 +598,17 @@ namespace PortingAssistant.Client.Analysis
                 CommonUtils.RunGarbageCollection(_logger, "PortingAssistantAnalysisHandler.AnalyzeProject");
             }
         }
-        
-        private AnalyzerConfiguration GetAnalyzerConfiguration(List<string> projects)
+
+        private AnalyzerConfiguration GetAnalyzerConfiguration(List<string> projects, AnalyzerSettings analyzerSettings = null)
         {
             var language = LanguageOptions.CSharp;
             if (projects != null && projects.Count > 0 & projects.Any(c => c.ToLower().EndsWith(".vbproj")))
             {
                 language = LanguageOptions.Vb;
             }
-            return new AnalyzerConfiguration(language)
-            {
-                MetaDataSettings =
+                return new AnalyzerConfiguration(language, analyzerSettings?.VisualStudioVersion.ToString())
+                {
+                    MetaDataSettings =
                     {
                         LiteralExpressions = true,
                         MethodInvocations = true,
@@ -617,8 +619,9 @@ namespace PortingAssistant.Client.Analysis
                         LocationData = true,
                         InterfaceDeclarations = true
                     },
-                ConcurrentThreads = 1
-            };
+                    ConcurrentThreads = 1
+                };
+            
         }
     }
 }

--- a/src/PortingAssistant.Client.Analysis/IAnalysisHandler.cs
+++ b/src/PortingAssistant.Client.Analysis/IAnalysisHandler.cs
@@ -9,15 +9,18 @@ namespace PortingAssistant.Client.Analysis
 {
     public interface IPortingAssistantAnalysisHandler
     {
-        Task<Dictionary<string, ProjectAnalysisResult>> AnalyzeSolution(string solutionFilename, List<string> projects, string targetFramework = "net6.0");
+        
+        Task<Dictionary<string, ProjectAnalysisResult>> AnalyzeSolution(string solutionFilename, List<string> projects, string targetFramework = "net6.0", AnalyzerSettings settings = null);
 
         Task<List<SourceFileAnalysisResult>> AnalyzeFileIncremental(string filePath, string projectFile, string solutionFileName, List<string> preportReferences
             , List<string> currentReferences, RootNodes rules, ExternalReferences externalReferences, bool actionsOnly, bool compatibleOnly, string targetFramework = "net6.0");
         Task<List<SourceFileAnalysisResult>> AnalyzeFileIncremental(string filePath, string fileContent, string projectFile, string solutionFileName, List<string> preportReferences
     , List<string> currentReferences, RootNodes rules, ExternalReferences externalReferences, bool actionsOnly, bool compatibleOnly, string targetFramework = "net6.0");
 
-        Task<Dictionary<string, ProjectAnalysisResult>> AnalyzeSolutionIncremental(string solutionFilename, List<string> projects,
-            string targetFramework = "net6.0");
+
+
+        Task<Dictionary<string, ProjectAnalysisResult>> AnalyzeSolutionIncremental(string solutionFilename, List<string> projects, 
+            string targetFramework = "net6.0", AnalyzerSettings settings = null);
 
         IAsyncEnumerable<ProjectAnalysisResult> AnalyzeSolutionGeneratorAsync(string solutionFilename, List<string> projects, string targetFramework = "net6.0");
     }

--- a/src/PortingAssistant.Client.Analysis/packages.lock.json
+++ b/src/PortingAssistant.Client.Analysis/packages.lock.json
@@ -67,12 +67,12 @@
       },
       "Codelyzer.Analysis": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "e5v8q0aGLvGkOklcbtWhxJ0BZczTNILUqxoTaD0TxJIy/t1YxoAaKWlPbele2n+DwUQNOf0PqKWU2Hurwwr/lw==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "BZF2Gx6yeGNoaLs7p4ppNsw9mASHXGhTWQwYXo+ZCw+ayfdNnNQ2qddm5/0FEnG1Fd7/9SEvNcj5Xz0qyDNVuQ==",
         "dependencies": {
-          "Codelyzer.Analysis.Build": "2.6.2",
-          "Codelyzer.Analysis.CSharp": "2.6.2",
-          "Codelyzer.Analysis.VisualBasic": "2.6.2",
+          "Codelyzer.Analysis.Build": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.CSharp": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.VisualBasic": "2.7.6-alpha-g61536c2540",
           "CommandLineParser": "2.8.0",
           "Microsoft.Build.Utilities.Core": "17.1.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
@@ -82,23 +82,23 @@
       },
       "Codelyzer.Analysis.Build": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "35reTFVRwBd0w/MyQkpUaoF4aejj1zPJcmTEbotmA+51+Zzkqvqwdn5Bkq+Ed8vqWNzzFCtWE6uClCp40TD0Kg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "DJbH6zVAOzn6nSdQ+gLW95PjS43iyWHUceY+ashysvKPnXDA+1iijWr2iySmH44m+y+pVNkMNhJCtCunvFm8XQ==",
         "dependencies": {
           "Buildalyzer": "4.1.4",
           "Buildalyzer.Logger": "4.1.4",
           "Buildalyzer.Workspaces": "4.1.4",
-          "Codelyzer.Analysis.Common": "2.6.2",
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
           "Microsoft.Extensions.Logging": "6.0.0",
           "NuGet.Packaging": "6.0.0"
         }
       },
       "Codelyzer.Analysis.Common": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "U1JL8Bs4zjF4mSIeVNYmXG/kNCg3iK5HcQmFec6Nw9WV6J+HaZLHHVI5i9QEb5i3y5rJHr6BRXvamSLDMwhNzg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "+VmZnZSlJxq5FHTKmWCtFmJi74AuegCltpg62zgvNjUd1Krf8x2tysgGALXe7+zXHMstcav8kd+UNcJ9Hd8opA==",
         "dependencies": {
-          "Codelyzer.Analysis.Model": "2.6.2",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540",
           "Microsoft.Build": "17.0.0",
           "Microsoft.VisualStudio.Setup.Configuration.Interop": "3.1.2196",
           "Newtonsoft.Json": "13.0.1"
@@ -106,17 +106,17 @@
       },
       "Codelyzer.Analysis.CSharp": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "5woKfZm0dmCBCHIv1sYHsKbeJ/TaFAdwjAAOf77jO+45HgBVnAmaoek94DMkE6ntxory13978pYhMI8VvBGbaQ==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "2KfxQ9oCNwYC6Km7F1J0kso/v9HwTjJawiJXRk51JA4bHz9JWYf/DyOhoN4/RuLTivRNiMRDF9vHdO3tDfgUdg==",
         "dependencies": {
-          "Codelyzer.Analysis.Common": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2"
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540"
         }
       },
       "Codelyzer.Analysis.Model": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "xEnO+h0TDVJ4ylc7Ta09EgcadAwKaV7JTNF3MirJ5JxIFJgXI9Wfob2zb1tUcbz8Hf4T9LHxwb1i8Dz2PZug3Q==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "D5sLdcv43QLEwW+q2RZhYkI8Q9F5d9CBGvE9+PIP7IuOCtTvbkjb4x3D/Yg/eySroJ4Fyb4oZtbCjOv9DMw8pw==",
         "dependencies": {
           "Microsoft.CodeAnalysis": "4.1.0",
           "Microsoft.CodeAnalysis.CSharp": "4.1.0",
@@ -127,11 +127,11 @@
       },
       "Codelyzer.Analysis.VisualBasic": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "LMgD0aumyHnEgxLeGEzF6FhyvbQSVZezeti3u0QTaMLb5/WDMVF973WGEEbnriYngJADeWOd8gOTOQNkAjz9gg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "YHPCvghN0zOFZ0ydDpnhQqiZeZkS3wOxi6f9anLhXflXlXr3t8SuRl/7ODhJ/BH2Yz7jLrf+xenyN4dFXFdlWQ==",
         "dependencies": {
-          "Codelyzer.Analysis.Common": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2"
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540"
         }
       },
       "CommandLineParser": {
@@ -141,91 +141,91 @@
       },
       "CTA.FeatureDetection": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "KRHdsuwtkyGRh0qhSQ80wW/cBLi7vcTQeFXSRfIhBlsX7gRZ6lU4Zty1QytVhVjeoXVk2VCfJHNm1wVx32xfLw==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "eQ7KTW2gEJ8gJOwt69y0yan6v5NbOphrdqriP/pwDnHoX6xkWPsQBcWm56ZtsshI0KVezlCqS02AuxX6LD20pQ==",
         "dependencies": {
-          "CTA.FeatureDetection.AuthType": "2.9.7",
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.FeatureDetection.Load": "2.9.7",
-          "CTA.FeatureDetection.ProjectType": "2.9.7",
-          "CTA.Rules.Common": "2.9.7"
+          "CTA.FeatureDetection.AuthType": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.Load": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.ProjectType": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.AuthType": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "NxVzyi10yPoF2xXdND66sMtuml3MCBxv1cKbfkJZMNMElqO57bc9GWmo6LF6bL/Io4uuneoT2GTurMRHD7MJgA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "4Nunc5gjYHgh8Sg1pnVw5M158gSdbENcxAesJUS/g54raaxxcVEtaSAWZ2XhkFnXI9LBQwQY/nwVWwRAw2eC9g==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.FeatureDetection.Common": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "dqXNobZ+/V9n0wk4Is2614fPFXhL5TSE+x0jDIHwcJ7pB5Pn3gD3MMDjHpV4Rq7EDyzIx980cvBOqQ0PdyWMzw==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "kVNJ5GUdo/AeJZNApSHAJnLE6fdNHKrreibPoGRLsxV8zP6YOWBox9ogfBgITTNaQj6AAstjudn+zWk4SGZ46g==",
         "dependencies": {
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7"
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.Load": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "T9RaHjGH4UUwAzVgNAYIjqHm9f2ycL0KocMPiyqQKE7rF0o31SUjtSWGlxLjr0ITUttHwQH051WJnM6o/flbcg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "VYSbH06dwqOz0KFHNzd7vzlXwhpWRXEwdtGIC/zvfw/f70RBzfr+2mcGg7DkA162B3keqNhPThSV1/rXdWsYDw==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.FeatureDetection.ProjectType": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.ProjectType": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.ProjectType": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "ubp9V7rBTuRNgKhrNFPqmFGlPrFdV18I0OxH2gMzdggYANu7Lb2rp/U+6vk0tUYyPlbMyTYcMZJ79/ZsIvS6Eg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "heNO09IAhGWWDayU+bmt0QFo0fiHjdrJdtC8YDKM/W+qrUYXoZGBN6wmJrrN3Iqiy5fi54Xp11CbbdVrr9ur/g==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Actions": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "tPm0TTDga8Jh5F2Fj60wpeKcll53e1DOvJdgC7OirKd7okIvJdSh43vuIbed3dS91MZ7qM4G7jfEf6uZ57O6tg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "ItRq6n84rjEnaqfLSOoqzhK/g9vtKuKlw58Z8qrhBNY1ncauTcdExmH92KMv7lxbOpqW3KSJP9M509cWcz9wWw==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Models": "2.9.7",
-          "CTA.Rules.ProjectFile": "2.9.7",
-          "CTA.WebForms": "2.9.7",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.ProjectFile": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.WebForms": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.Rules.Analysis": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "7W++wHGBSHcMswPOS8X8hIJB98gvU4F/TIV4eYB46JDaT7HUHP8BC/MlYLAxdXlk3khOzWiVmz2uWPQQ2vOlvA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "yCNRLXZA0U5jz1Dm86OeFiiWM0dP8QZ4qGzCCoPtDqKw3cP5/RB4Yld1VykU8S/y2bQCpye1qmPCVaIRv0egnA==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Common": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "Yn29oIRx13AmYQ2vPIL5IrOq0DxtwHxuRpy4ojklbhBoHZytjA/0VltIX9vUxZ86zX6/PzcV6lM1prxAXuAw3A==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "mz5lzdfUZ50ti9Tn85WiW03goN/Dqv/0Ao0aghvr0o+z5/EqZXg5OtbqHyXPR7plY819Y61DO4vRudd7Fz7BVQ==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.Rules.Config": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "o2IkxdBu94pjxDIQj4iwwU+C8aGl42auSr+DoxIssfh7eSXox/PUISy34XCqtZRtYnv/MY8dc3/JeDGy/7jaXA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "NOX3Z4pjf6JtL75Ojd0Mk1cypIUCNmirD+tw7ERvpC6BCNOTFY5kT0yq3zHr0NEtDNYcs/59bUt2fwEi7i4j8A==",
         "dependencies": {
-          "Codelyzer.Analysis": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2",
+          "Codelyzer.Analysis": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
@@ -234,72 +234,72 @@
       },
       "CTA.Rules.Metrics": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "MN7Q2GbEnf1SSlaDntXerXYWPDjqKnKybT9sMmFxuMzLvSQBqkApaA/mWDNFcyP4TlGa3TsQy6aeISkKmfwueg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "BHrfMcGQk/CbdP1ut4ad1ktsVRMV1CcYfe0yFjQj9FMQCyZXxDChPvRErgj6Q2Y/Y0UTO85LvALmz63wU6MsZQ==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Models": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "BZYUirb+FNpH/0ULM9z7zvHkpBW/fSiOM5wE8VrT3w+Kz0rOHa73dwx/KgQ7LWxnzCM+aO1ZOIq44YldVMMHyQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "rzKahcwVY37C/OiAzQjjZ/JGW0HaHfe5vxMcsnkuodd+4vOg1dZd70dCQ50bj+1Ngqu42fhoZYhGXO87tgDBnw==",
         "dependencies": {
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.ComponentModel.Annotations": "5.0.0"
         }
       },
       "CTA.Rules.PortCore": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "3q6GFuUZA9nDEZvtVkmmvtcOf1Rt1kstC1Q6+oMb6mrrXIvSktd2N8FGSe4yMxtmA1OXDj/rkNRJ2fQsK0ELiQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "AkM3Ho2/Z/R+C8DBWrOzS5pnxT438SNOKIBFD8yXVBMJfnC3UcC0Omp9CstuP5IeGNXjn8ME8iu57xI7ubB8SA==",
         "dependencies": {
-          "CTA.FeatureDetection": "2.9.7",
-          "CTA.Rules.Update": "2.9.7",
-          "CTA.WebForms": "2.9.7"
+          "CTA.FeatureDetection": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Update": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.WebForms": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.ProjectFile": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "J7Lr22BrTvl1MfN2r93R77wLOp503/ddK1XYRKHdArFFnqeo7X3ydlYST3aDO67Zjd1KAWS0fLrClvD3+R1YgA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "1IIqz+FLHxoCi15UEC5xMgTEiVxs0jGmvTjQ6Il/xO7E9wborXTPK2rojNcbbzvdRSB3MrkQfPEU/h//kvLcHQ==",
         "dependencies": {
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.RuleFiles": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "0mKZlYfuyLiJcOgFlVaE2qKyXBXMW83BB7Pr7/zMyEi0E8ORC4i5ZPNyS/uxGl7QOs3N+c1Ym90tHhUu/uN81w==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "+QBiE6lR6plBRdtM6CVTLHY8i7Ge+sDwRKlULV/yTX/vMjWfFJny5N1HDmu8g2e3P7RuqeUluZqAWFNVPq94jA==",
         "dependencies": {
-          "CTA.Rules.Actions": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Actions": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Update": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "ZzH0ZPLg4mu8GgQ96mzTT41ph4BN8L5XqunVHbdmM82VyJr4Cu6c42B0EQSALRqOcTHBtt39Cle6NRX2wv7agQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "LEMaWzPJnhOgLY8LZDFXUWPWwvkeO2FKlEdu+gwSe8Obn8eFtTJFdccQJ+0Q1LCrtvqcPTAoPjZXAs/t8nZmvA==",
         "dependencies": {
-          "CTA.Rules.Actions": "2.9.7",
-          "CTA.Rules.Analysis": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7",
-          "CTA.Rules.ProjectFile": "2.9.7",
-          "CTA.Rules.RuleFiles": "2.9.7"
+          "CTA.Rules.Actions": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Analysis": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.ProjectFile": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.RuleFiles": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.WebForms": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "oF+QkuvrfLB1ke+vaxlXwYFfMHY5KqZLU0A46/d7hfzkuF9zxnLNIL7V9pel8wpRgAbOM79gPwPeJ8DiVFXvJg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "qXwHq0qHLd7EWEVJwzHfmtaa8U7uB+YQsQ2zBTqARdrtLnKVUu5Oq34nB6hldMelbJZKSvO6Fh1X6CoaAXWZAg==",
         "dependencies": {
-          "CTA.Rules.Models": "2.9.7",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
           "HtmlAgilityPack": "1.11.42",
           "YamlDotNet": "11.2.1"
         }
@@ -1954,7 +1954,7 @@
       "portingassistant.client.common": {
         "type": "Project",
         "dependencies": {
-          "CTA.Rules.PortCore": "[2.9.7, )",
+          "CTA.Rules.PortCore": "[2.11.7-alpha-g2ff9aaed0c, )",
           "Newtonsoft.Json": "[13.0.1, )",
           "NuGet.Protocol": "[6.5.0, )",
           "Serilog.Extensions.Logging": "[3.0.1, )",

--- a/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
+++ b/src/PortingAssistant.Client.Client/PortingAssistantClient.cs
@@ -41,9 +41,9 @@ namespace PortingAssistant.Client.Client
                 Dictionary<string, ProjectAnalysisResult> projectAnalysisResultsDict;
 
                 if (settings.ContiniousEnabled)
-                    projectAnalysisResultsDict = await _analysisHandler.AnalyzeSolutionIncremental(solutionFilePath, projects, targetFramework);
+                    projectAnalysisResultsDict = await _analysisHandler.AnalyzeSolutionIncremental(solutionFilePath, projects, targetFramework, settings);
                 else
-                    projectAnalysisResultsDict = await _analysisHandler.AnalyzeSolution(solutionFilePath, projects, targetFramework);
+                    projectAnalysisResultsDict = await _analysisHandler.AnalyzeSolution(solutionFilePath, projects, targetFramework, settings);
 
                 var projectAnalysisResults = projects.Select(p =>
                 {
@@ -172,7 +172,7 @@ namespace PortingAssistant.Client.Client
                     request.SolutionPath,
                     request.TargetFramework,
                     request.IncludeCodeFix,
-                    upgradeVersions);
+                    upgradeVersions, request.VisualStudioVersion);
             }
             catch (Exception ex)
             {

--- a/src/PortingAssistant.Client.Common/Model/AnalyzerSettings.cs
+++ b/src/PortingAssistant.Client.Common/Model/AnalyzerSettings.cs
@@ -16,5 +16,7 @@ namespace PortingAssistant.Client.Model
         public bool ActionsOnly { get; set; }
 
         public bool UseGenerator { get; set; }
+
+        public VisualStudioVersion? VisualStudioVersion { get; set; }
     }
 }

--- a/src/PortingAssistant.Client.Common/Model/PortingRequest.cs
+++ b/src/PortingAssistant.Client.Common/Model/PortingRequest.cs
@@ -10,5 +10,6 @@ namespace PortingAssistant.Client.Model
         public string TargetFramework { get; set; }
         public List<RecommendedAction> RecommendedActions { get; set; }
         public bool IncludeCodeFix { get; set; }
+        public VisualStudioVersion? VisualStudioVersion { get; set; }
     }
 }

--- a/src/PortingAssistant.Client.Common/Model/VisualStudioVersion.cs
+++ b/src/PortingAssistant.Client.Common/Model/VisualStudioVersion.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PortingAssistant.Client.Model
+{
+    public enum VisualStudioVersion
+    {
+        VS2019,
+        VS2022
+    }
+}

--- a/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
+++ b/src/PortingAssistant.Client.Common/PortingAssistant.Client.Common.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CTA.Rules.PortCore" Version="2.10.11" />
+    <PackageReference Include="CTA.Rules.PortCore" Version="2.11.7-alpha-g2ff9aaed0c" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.5.0" />
     <PackageReference Include="semver" Version="2.0.6" />

--- a/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
+++ b/src/PortingAssistant.Client.Common/Utils/MemoryUtils.cs
@@ -63,8 +63,9 @@ namespace PortingAssistant.Client.Common.Utils
         // Summary:
         //     This method takes a logger, path to a solution file, and logs
         //     the total size of the solution, in bytes, by suming up the
-        //     size of each cs file contained in the solution.
-        public static void LogSolutiontSize(ILogger logger, string SolutionPath)
+        //     size of each cs file contained in the solution. Then, it
+        //     returns the size.
+        public static long LogSolutionSize(ILogger logger, string SolutionPath)
         {
             DirectoryInfo solutionDir = Directory.GetParent(SolutionPath);
             var size = solutionDir.EnumerateFiles(
@@ -72,6 +73,7 @@ namespace PortingAssistant.Client.Common.Utils
             logger.LogInformation(
                 "Total size for {0} in bytes: {1}",
                 SolutionPath, size);
+            return size;
         }
 
         //

--- a/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
+++ b/src/PortingAssistant.Client.NuGet/Checkers/ExternalCompatibilityChecker.cs
@@ -135,7 +135,7 @@ namespace PortingAssistant.Client.NuGet
                 catch (OutOfMemoryException ex)
                 {
                     _logger.LogError("Failed when downloading and parsing {0} from {1}, {2}", fileToDownload, CompatibilityCheckerType, ex);
-                    MemoryUtils.LogSolutiontSize(_logger, pathToSolution);
+                    MemoryUtils.LogSolutionSize(_logger, pathToSolution);
                     MemoryUtils.LogMemoryConsumption(_logger);
                 }
                 catch (Exception ex)

--- a/src/PortingAssistant.Client.Porting/IPortingHandler.cs
+++ b/src/PortingAssistant.Client.Porting/IPortingHandler.cs
@@ -21,7 +21,7 @@ namespace PortingAssistant.Client.Porting
             List<ProjectDetails> projects,
             string solutionPath,
             string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions);
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null);
 
         /// <summary>
         /// Ports a list of projects
@@ -36,6 +36,6 @@ namespace PortingAssistant.Client.Porting
             string solutionPath,
             string targetFramework,
             bool includeCodeFix,
-            Dictionary<string, Tuple<string, string>> upgradeVersions);
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null);
     }
 }

--- a/src/PortingAssistant.Client.Porting/IPortingHandler.cs
+++ b/src/PortingAssistant.Client.Porting/IPortingHandler.cs
@@ -21,7 +21,7 @@ namespace PortingAssistant.Client.Porting
             List<ProjectDetails> projects,
             string solutionPath,
             string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null);
+            Dictionary<string, Tuple<string, string>> upgradeVersions);
 
         /// <summary>
         /// Ports a list of projects

--- a/src/PortingAssistant.Client.Porting/PortingHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingHandler.cs
@@ -29,9 +29,9 @@ namespace PortingAssistant.Client.Porting
         /// <returns>A PortingProjectFileResult object, representing the result of the porting operation</returns>
         public List<PortingResult> ApplyPortProjectFileChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null)
+            Dictionary<string, Tuple<string, string>> upgradeVersions)
         {
-            return ApplyPortProjectFileChanges(projects, solutionPath, targetFramework, true, upgradeVersions, visualStudioVersion);
+            return ApplyPortProjectFileChanges(projects, solutionPath, targetFramework, true, upgradeVersions);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace PortingAssistant.Client.Porting
         public List<PortingResult> ApplyPortProjectFileChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
             bool includeCodeFix,
-            Dictionary<string, Tuple<string, string>> upgradeVersions,  VisualStudioVersion? visualStudioVersion = null)
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null)
         {
             return _portingProjectFileHandler.ApplyProjectChanges(projects, solutionPath, targetFramework, includeCodeFix, upgradeVersions, visualStudioVersion);
         }

--- a/src/PortingAssistant.Client.Porting/PortingHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingHandler.cs
@@ -29,9 +29,9 @@ namespace PortingAssistant.Client.Porting
         /// <returns>A PortingProjectFileResult object, representing the result of the porting operation</returns>
         public List<PortingResult> ApplyPortProjectFileChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions)
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null)
         {
-            return ApplyPortProjectFileChanges(projects, solutionPath, targetFramework, true, upgradeVersions);
+            return ApplyPortProjectFileChanges(projects, solutionPath, targetFramework, true, upgradeVersions, visualStudioVersion);
         }
 
         /// <summary>
@@ -45,9 +45,9 @@ namespace PortingAssistant.Client.Porting
         public List<PortingResult> ApplyPortProjectFileChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
             bool includeCodeFix,
-            Dictionary<string, Tuple<string, string>> upgradeVersions)
+            Dictionary<string, Tuple<string, string>> upgradeVersions,  VisualStudioVersion? visualStudioVersion = null)
         {
-            return _portingProjectFileHandler.ApplyProjectChanges(projects, solutionPath, targetFramework, includeCodeFix, upgradeVersions);
+            return _portingProjectFileHandler.ApplyProjectChanges(projects, solutionPath, targetFramework, includeCodeFix, upgradeVersions, visualStudioVersion);
         }
 
     }

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/IPortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/IPortingProjectFileHandler.cs
@@ -19,7 +19,7 @@ namespace PortingAssistant.Client.PortingProjectFile
         /// <returns>A PortingProjectFileResult object, representing the result of the porting operation</returns>
         List<PortingResult> ApplyProjectChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null);
+            Dictionary<string, Tuple<string, string>> upgradeVersions);
 
         /// <summary>
         /// Ports a list of projects

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/IPortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/IPortingProjectFileHandler.cs
@@ -19,7 +19,7 @@ namespace PortingAssistant.Client.PortingProjectFile
         /// <returns>A PortingProjectFileResult object, representing the result of the porting operation</returns>
         List<PortingResult> ApplyProjectChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions);
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null);
 
         /// <summary>
         /// Ports a list of projects
@@ -32,6 +32,6 @@ namespace PortingAssistant.Client.PortingProjectFile
         List<PortingResult> ApplyProjectChanges(
             List<ProjectDetails> projects, string solutionPath, string targetFramework,
             bool includeCodeFix,
-            Dictionary<string, Tuple<string, string>> upgradeVersions);
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null);
     }
 }

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
@@ -38,9 +38,9 @@ namespace PortingAssistant.Client.PortingProjectFile
             List<ProjectDetails> projects, 
             string solutionPath, 
             string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions)
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null)
         {
-            return ApplyProjectChanges(projects, solutionPath, targetFramework, true, upgradeVersions);
+            return ApplyProjectChanges(projects, solutionPath, targetFramework, true, upgradeVersions, visualStudioVersion);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace PortingAssistant.Client.PortingProjectFile
             string solutionPath, 
             string targetFramework,
             bool includeCodeFix,
-            Dictionary<string, Tuple<string, string>> upgradeVersions)
+            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null)
         {
             var results = new List<PortingResult>();
 
@@ -97,7 +97,7 @@ namespace PortingAssistant.Client.PortingProjectFile
 
             try
             {
-                SolutionPort solutionPort = new SolutionPort(solutionPath, configs, _logger);
+                SolutionPort solutionPort = new SolutionPort(solutionPath, configs, _logger, visualStudioVersion?.ToString());
                 solutionPort.Run();
             }
             catch (Exception ex)

--- a/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
+++ b/src/PortingAssistant.Client.Porting/PortingProjectFile/PortingProjectFileHandler.cs
@@ -38,9 +38,9 @@ namespace PortingAssistant.Client.PortingProjectFile
             List<ProjectDetails> projects, 
             string solutionPath, 
             string targetFramework,
-            Dictionary<string, Tuple<string, string>> upgradeVersions, VisualStudioVersion? visualStudioVersion = null)
+            Dictionary<string, Tuple<string, string>> upgradeVersions)
         {
-            return ApplyProjectChanges(projects, solutionPath, targetFramework, true, upgradeVersions, visualStudioVersion);
+            return ApplyProjectChanges(projects, solutionPath, targetFramework, true, upgradeVersions);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace PortingAssistant.Client.PortingProjectFile
 
             try
             {
-                SolutionPort solutionPort = new SolutionPort(solutionPath, configs, _logger, visualStudioVersion?.ToString());
+                SolutionPort solutionPort = new SolutionPort(solutionPath, configs, _logger, visualStudioVersion: visualStudioVersion?.ToString());
                 solutionPort.Run();
             }
             catch (Exception ex)

--- a/src/PortingAssistant.Client.Porting/packages.lock.json
+++ b/src/PortingAssistant.Client.Porting/packages.lock.json
@@ -54,12 +54,12 @@
       },
       "Codelyzer.Analysis": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "e5v8q0aGLvGkOklcbtWhxJ0BZczTNILUqxoTaD0TxJIy/t1YxoAaKWlPbele2n+DwUQNOf0PqKWU2Hurwwr/lw==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "BZF2Gx6yeGNoaLs7p4ppNsw9mASHXGhTWQwYXo+ZCw+ayfdNnNQ2qddm5/0FEnG1Fd7/9SEvNcj5Xz0qyDNVuQ==",
         "dependencies": {
-          "Codelyzer.Analysis.Build": "2.6.2",
-          "Codelyzer.Analysis.CSharp": "2.6.2",
-          "Codelyzer.Analysis.VisualBasic": "2.6.2",
+          "Codelyzer.Analysis.Build": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.CSharp": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.VisualBasic": "2.7.6-alpha-g61536c2540",
           "CommandLineParser": "2.8.0",
           "Microsoft.Build.Utilities.Core": "17.1.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
@@ -69,23 +69,23 @@
       },
       "Codelyzer.Analysis.Build": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "35reTFVRwBd0w/MyQkpUaoF4aejj1zPJcmTEbotmA+51+Zzkqvqwdn5Bkq+Ed8vqWNzzFCtWE6uClCp40TD0Kg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "DJbH6zVAOzn6nSdQ+gLW95PjS43iyWHUceY+ashysvKPnXDA+1iijWr2iySmH44m+y+pVNkMNhJCtCunvFm8XQ==",
         "dependencies": {
           "Buildalyzer": "4.1.4",
           "Buildalyzer.Logger": "4.1.4",
           "Buildalyzer.Workspaces": "4.1.4",
-          "Codelyzer.Analysis.Common": "2.6.2",
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
           "Microsoft.Extensions.Logging": "6.0.0",
           "NuGet.Packaging": "6.0.0"
         }
       },
       "Codelyzer.Analysis.Common": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "U1JL8Bs4zjF4mSIeVNYmXG/kNCg3iK5HcQmFec6Nw9WV6J+HaZLHHVI5i9QEb5i3y5rJHr6BRXvamSLDMwhNzg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "+VmZnZSlJxq5FHTKmWCtFmJi74AuegCltpg62zgvNjUd1Krf8x2tysgGALXe7+zXHMstcav8kd+UNcJ9Hd8opA==",
         "dependencies": {
-          "Codelyzer.Analysis.Model": "2.6.2",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540",
           "Microsoft.Build": "17.0.0",
           "Microsoft.VisualStudio.Setup.Configuration.Interop": "3.1.2196",
           "Newtonsoft.Json": "13.0.1"
@@ -93,17 +93,17 @@
       },
       "Codelyzer.Analysis.CSharp": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "5woKfZm0dmCBCHIv1sYHsKbeJ/TaFAdwjAAOf77jO+45HgBVnAmaoek94DMkE6ntxory13978pYhMI8VvBGbaQ==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "2KfxQ9oCNwYC6Km7F1J0kso/v9HwTjJawiJXRk51JA4bHz9JWYf/DyOhoN4/RuLTivRNiMRDF9vHdO3tDfgUdg==",
         "dependencies": {
-          "Codelyzer.Analysis.Common": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2"
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540"
         }
       },
       "Codelyzer.Analysis.Model": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "xEnO+h0TDVJ4ylc7Ta09EgcadAwKaV7JTNF3MirJ5JxIFJgXI9Wfob2zb1tUcbz8Hf4T9LHxwb1i8Dz2PZug3Q==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "D5sLdcv43QLEwW+q2RZhYkI8Q9F5d9CBGvE9+PIP7IuOCtTvbkjb4x3D/Yg/eySroJ4Fyb4oZtbCjOv9DMw8pw==",
         "dependencies": {
           "Microsoft.CodeAnalysis": "4.1.0",
           "Microsoft.CodeAnalysis.CSharp": "4.1.0",
@@ -114,11 +114,11 @@
       },
       "Codelyzer.Analysis.VisualBasic": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "LMgD0aumyHnEgxLeGEzF6FhyvbQSVZezeti3u0QTaMLb5/WDMVF973WGEEbnriYngJADeWOd8gOTOQNkAjz9gg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "YHPCvghN0zOFZ0ydDpnhQqiZeZkS3wOxi6f9anLhXflXlXr3t8SuRl/7ODhJ/BH2Yz7jLrf+xenyN4dFXFdlWQ==",
         "dependencies": {
-          "Codelyzer.Analysis.Common": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2"
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540"
         }
       },
       "CommandLineParser": {
@@ -128,91 +128,91 @@
       },
       "CTA.FeatureDetection": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "KRHdsuwtkyGRh0qhSQ80wW/cBLi7vcTQeFXSRfIhBlsX7gRZ6lU4Zty1QytVhVjeoXVk2VCfJHNm1wVx32xfLw==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "eQ7KTW2gEJ8gJOwt69y0yan6v5NbOphrdqriP/pwDnHoX6xkWPsQBcWm56ZtsshI0KVezlCqS02AuxX6LD20pQ==",
         "dependencies": {
-          "CTA.FeatureDetection.AuthType": "2.9.7",
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.FeatureDetection.Load": "2.9.7",
-          "CTA.FeatureDetection.ProjectType": "2.9.7",
-          "CTA.Rules.Common": "2.9.7"
+          "CTA.FeatureDetection.AuthType": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.Load": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.ProjectType": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.AuthType": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "NxVzyi10yPoF2xXdND66sMtuml3MCBxv1cKbfkJZMNMElqO57bc9GWmo6LF6bL/Io4uuneoT2GTurMRHD7MJgA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "4Nunc5gjYHgh8Sg1pnVw5M158gSdbENcxAesJUS/g54raaxxcVEtaSAWZ2XhkFnXI9LBQwQY/nwVWwRAw2eC9g==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.FeatureDetection.Common": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "dqXNobZ+/V9n0wk4Is2614fPFXhL5TSE+x0jDIHwcJ7pB5Pn3gD3MMDjHpV4Rq7EDyzIx980cvBOqQ0PdyWMzw==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "kVNJ5GUdo/AeJZNApSHAJnLE6fdNHKrreibPoGRLsxV8zP6YOWBox9ogfBgITTNaQj6AAstjudn+zWk4SGZ46g==",
         "dependencies": {
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7"
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.Load": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "T9RaHjGH4UUwAzVgNAYIjqHm9f2ycL0KocMPiyqQKE7rF0o31SUjtSWGlxLjr0ITUttHwQH051WJnM6o/flbcg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "VYSbH06dwqOz0KFHNzd7vzlXwhpWRXEwdtGIC/zvfw/f70RBzfr+2mcGg7DkA162B3keqNhPThSV1/rXdWsYDw==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.FeatureDetection.ProjectType": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.ProjectType": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.ProjectType": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "ubp9V7rBTuRNgKhrNFPqmFGlPrFdV18I0OxH2gMzdggYANu7Lb2rp/U+6vk0tUYyPlbMyTYcMZJ79/ZsIvS6Eg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "heNO09IAhGWWDayU+bmt0QFo0fiHjdrJdtC8YDKM/W+qrUYXoZGBN6wmJrrN3Iqiy5fi54Xp11CbbdVrr9ur/g==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Actions": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "tPm0TTDga8Jh5F2Fj60wpeKcll53e1DOvJdgC7OirKd7okIvJdSh43vuIbed3dS91MZ7qM4G7jfEf6uZ57O6tg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "ItRq6n84rjEnaqfLSOoqzhK/g9vtKuKlw58Z8qrhBNY1ncauTcdExmH92KMv7lxbOpqW3KSJP9M509cWcz9wWw==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Models": "2.9.7",
-          "CTA.Rules.ProjectFile": "2.9.7",
-          "CTA.WebForms": "2.9.7",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.ProjectFile": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.WebForms": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.Rules.Analysis": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "7W++wHGBSHcMswPOS8X8hIJB98gvU4F/TIV4eYB46JDaT7HUHP8BC/MlYLAxdXlk3khOzWiVmz2uWPQQ2vOlvA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "yCNRLXZA0U5jz1Dm86OeFiiWM0dP8QZ4qGzCCoPtDqKw3cP5/RB4Yld1VykU8S/y2bQCpye1qmPCVaIRv0egnA==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Common": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "Yn29oIRx13AmYQ2vPIL5IrOq0DxtwHxuRpy4ojklbhBoHZytjA/0VltIX9vUxZ86zX6/PzcV6lM1prxAXuAw3A==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "mz5lzdfUZ50ti9Tn85WiW03goN/Dqv/0Ao0aghvr0o+z5/EqZXg5OtbqHyXPR7plY819Y61DO4vRudd7Fz7BVQ==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.Rules.Config": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "o2IkxdBu94pjxDIQj4iwwU+C8aGl42auSr+DoxIssfh7eSXox/PUISy34XCqtZRtYnv/MY8dc3/JeDGy/7jaXA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "NOX3Z4pjf6JtL75Ojd0Mk1cypIUCNmirD+tw7ERvpC6BCNOTFY5kT0yq3zHr0NEtDNYcs/59bUt2fwEi7i4j8A==",
         "dependencies": {
-          "Codelyzer.Analysis": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2",
+          "Codelyzer.Analysis": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
@@ -221,72 +221,72 @@
       },
       "CTA.Rules.Metrics": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "MN7Q2GbEnf1SSlaDntXerXYWPDjqKnKybT9sMmFxuMzLvSQBqkApaA/mWDNFcyP4TlGa3TsQy6aeISkKmfwueg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "BHrfMcGQk/CbdP1ut4ad1ktsVRMV1CcYfe0yFjQj9FMQCyZXxDChPvRErgj6Q2Y/Y0UTO85LvALmz63wU6MsZQ==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Models": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "BZYUirb+FNpH/0ULM9z7zvHkpBW/fSiOM5wE8VrT3w+Kz0rOHa73dwx/KgQ7LWxnzCM+aO1ZOIq44YldVMMHyQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "rzKahcwVY37C/OiAzQjjZ/JGW0HaHfe5vxMcsnkuodd+4vOg1dZd70dCQ50bj+1Ngqu42fhoZYhGXO87tgDBnw==",
         "dependencies": {
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.ComponentModel.Annotations": "5.0.0"
         }
       },
       "CTA.Rules.PortCore": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "3q6GFuUZA9nDEZvtVkmmvtcOf1Rt1kstC1Q6+oMb6mrrXIvSktd2N8FGSe4yMxtmA1OXDj/rkNRJ2fQsK0ELiQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "AkM3Ho2/Z/R+C8DBWrOzS5pnxT438SNOKIBFD8yXVBMJfnC3UcC0Omp9CstuP5IeGNXjn8ME8iu57xI7ubB8SA==",
         "dependencies": {
-          "CTA.FeatureDetection": "2.9.7",
-          "CTA.Rules.Update": "2.9.7",
-          "CTA.WebForms": "2.9.7"
+          "CTA.FeatureDetection": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Update": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.WebForms": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.ProjectFile": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "J7Lr22BrTvl1MfN2r93R77wLOp503/ddK1XYRKHdArFFnqeo7X3ydlYST3aDO67Zjd1KAWS0fLrClvD3+R1YgA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "1IIqz+FLHxoCi15UEC5xMgTEiVxs0jGmvTjQ6Il/xO7E9wborXTPK2rojNcbbzvdRSB3MrkQfPEU/h//kvLcHQ==",
         "dependencies": {
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.RuleFiles": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "0mKZlYfuyLiJcOgFlVaE2qKyXBXMW83BB7Pr7/zMyEi0E8ORC4i5ZPNyS/uxGl7QOs3N+c1Ym90tHhUu/uN81w==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "+QBiE6lR6plBRdtM6CVTLHY8i7Ge+sDwRKlULV/yTX/vMjWfFJny5N1HDmu8g2e3P7RuqeUluZqAWFNVPq94jA==",
         "dependencies": {
-          "CTA.Rules.Actions": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Actions": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Update": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "ZzH0ZPLg4mu8GgQ96mzTT41ph4BN8L5XqunVHbdmM82VyJr4Cu6c42B0EQSALRqOcTHBtt39Cle6NRX2wv7agQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "LEMaWzPJnhOgLY8LZDFXUWPWwvkeO2FKlEdu+gwSe8Obn8eFtTJFdccQJ+0Q1LCrtvqcPTAoPjZXAs/t8nZmvA==",
         "dependencies": {
-          "CTA.Rules.Actions": "2.9.7",
-          "CTA.Rules.Analysis": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7",
-          "CTA.Rules.ProjectFile": "2.9.7",
-          "CTA.Rules.RuleFiles": "2.9.7"
+          "CTA.Rules.Actions": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Analysis": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.ProjectFile": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.RuleFiles": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.WebForms": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "oF+QkuvrfLB1ke+vaxlXwYFfMHY5KqZLU0A46/d7hfzkuF9zxnLNIL7V9pel8wpRgAbOM79gPwPeJ8DiVFXvJg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "qXwHq0qHLd7EWEVJwzHfmtaa8U7uB+YQsQ2zBTqARdrtLnKVUu5Oq34nB6hldMelbJZKSvO6Fh1X6CoaAXWZAg==",
         "dependencies": {
-          "CTA.Rules.Models": "2.9.7",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
           "HtmlAgilityPack": "1.11.42",
           "YamlDotNet": "11.2.1"
         }
@@ -1930,7 +1930,7 @@
       "portingassistant.client.common": {
         "type": "Project",
         "dependencies": {
-          "CTA.Rules.PortCore": "[2.9.7, )",
+          "CTA.Rules.PortCore": "[2.11.7-alpha-g2ff9aaed0c, )",
           "Newtonsoft.Json": "[13.0.1, )",
           "NuGet.Protocol": "[6.5.0, )",
           "Serilog.Extensions.Logging": "[3.0.1, )",

--- a/src/PortingAssistant.Client.Telemetry/packages.lock.json
+++ b/src/PortingAssistant.Client.Telemetry/packages.lock.json
@@ -117,12 +117,12 @@
       },
       "Codelyzer.Analysis": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "e5v8q0aGLvGkOklcbtWhxJ0BZczTNILUqxoTaD0TxJIy/t1YxoAaKWlPbele2n+DwUQNOf0PqKWU2Hurwwr/lw==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "BZF2Gx6yeGNoaLs7p4ppNsw9mASHXGhTWQwYXo+ZCw+ayfdNnNQ2qddm5/0FEnG1Fd7/9SEvNcj5Xz0qyDNVuQ==",
         "dependencies": {
-          "Codelyzer.Analysis.Build": "2.6.2",
-          "Codelyzer.Analysis.CSharp": "2.6.2",
-          "Codelyzer.Analysis.VisualBasic": "2.6.2",
+          "Codelyzer.Analysis.Build": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.CSharp": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.VisualBasic": "2.7.6-alpha-g61536c2540",
           "CommandLineParser": "2.8.0",
           "Microsoft.Build.Utilities.Core": "17.1.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
@@ -132,23 +132,23 @@
       },
       "Codelyzer.Analysis.Build": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "35reTFVRwBd0w/MyQkpUaoF4aejj1zPJcmTEbotmA+51+Zzkqvqwdn5Bkq+Ed8vqWNzzFCtWE6uClCp40TD0Kg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "DJbH6zVAOzn6nSdQ+gLW95PjS43iyWHUceY+ashysvKPnXDA+1iijWr2iySmH44m+y+pVNkMNhJCtCunvFm8XQ==",
         "dependencies": {
           "Buildalyzer": "4.1.4",
           "Buildalyzer.Logger": "4.1.4",
           "Buildalyzer.Workspaces": "4.1.4",
-          "Codelyzer.Analysis.Common": "2.6.2",
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
           "Microsoft.Extensions.Logging": "6.0.0",
           "NuGet.Packaging": "6.0.0"
         }
       },
       "Codelyzer.Analysis.Common": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "U1JL8Bs4zjF4mSIeVNYmXG/kNCg3iK5HcQmFec6Nw9WV6J+HaZLHHVI5i9QEb5i3y5rJHr6BRXvamSLDMwhNzg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "+VmZnZSlJxq5FHTKmWCtFmJi74AuegCltpg62zgvNjUd1Krf8x2tysgGALXe7+zXHMstcav8kd+UNcJ9Hd8opA==",
         "dependencies": {
-          "Codelyzer.Analysis.Model": "2.6.2",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540",
           "Microsoft.Build": "17.0.0",
           "Microsoft.VisualStudio.Setup.Configuration.Interop": "3.1.2196",
           "Newtonsoft.Json": "13.0.1"
@@ -156,17 +156,17 @@
       },
       "Codelyzer.Analysis.CSharp": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "5woKfZm0dmCBCHIv1sYHsKbeJ/TaFAdwjAAOf77jO+45HgBVnAmaoek94DMkE6ntxory13978pYhMI8VvBGbaQ==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "2KfxQ9oCNwYC6Km7F1J0kso/v9HwTjJawiJXRk51JA4bHz9JWYf/DyOhoN4/RuLTivRNiMRDF9vHdO3tDfgUdg==",
         "dependencies": {
-          "Codelyzer.Analysis.Common": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2"
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540"
         }
       },
       "Codelyzer.Analysis.Model": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "xEnO+h0TDVJ4ylc7Ta09EgcadAwKaV7JTNF3MirJ5JxIFJgXI9Wfob2zb1tUcbz8Hf4T9LHxwb1i8Dz2PZug3Q==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "D5sLdcv43QLEwW+q2RZhYkI8Q9F5d9CBGvE9+PIP7IuOCtTvbkjb4x3D/Yg/eySroJ4Fyb4oZtbCjOv9DMw8pw==",
         "dependencies": {
           "Microsoft.CodeAnalysis": "4.1.0",
           "Microsoft.CodeAnalysis.CSharp": "4.1.0",
@@ -177,11 +177,11 @@
       },
       "Codelyzer.Analysis.VisualBasic": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "LMgD0aumyHnEgxLeGEzF6FhyvbQSVZezeti3u0QTaMLb5/WDMVF973WGEEbnriYngJADeWOd8gOTOQNkAjz9gg==",
+        "resolved": "2.7.6-alpha-g61536c2540",
+        "contentHash": "YHPCvghN0zOFZ0ydDpnhQqiZeZkS3wOxi6f9anLhXflXlXr3t8SuRl/7ODhJ/BH2Yz7jLrf+xenyN4dFXFdlWQ==",
         "dependencies": {
-          "Codelyzer.Analysis.Common": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2"
+          "Codelyzer.Analysis.Common": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540"
         }
       },
       "CommandLineParser": {
@@ -191,91 +191,91 @@
       },
       "CTA.FeatureDetection": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "KRHdsuwtkyGRh0qhSQ80wW/cBLi7vcTQeFXSRfIhBlsX7gRZ6lU4Zty1QytVhVjeoXVk2VCfJHNm1wVx32xfLw==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "eQ7KTW2gEJ8gJOwt69y0yan6v5NbOphrdqriP/pwDnHoX6xkWPsQBcWm56ZtsshI0KVezlCqS02AuxX6LD20pQ==",
         "dependencies": {
-          "CTA.FeatureDetection.AuthType": "2.9.7",
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.FeatureDetection.Load": "2.9.7",
-          "CTA.FeatureDetection.ProjectType": "2.9.7",
-          "CTA.Rules.Common": "2.9.7"
+          "CTA.FeatureDetection.AuthType": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.Load": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.ProjectType": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.AuthType": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "NxVzyi10yPoF2xXdND66sMtuml3MCBxv1cKbfkJZMNMElqO57bc9GWmo6LF6bL/Io4uuneoT2GTurMRHD7MJgA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "4Nunc5gjYHgh8Sg1pnVw5M158gSdbENcxAesJUS/g54raaxxcVEtaSAWZ2XhkFnXI9LBQwQY/nwVWwRAw2eC9g==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.FeatureDetection.Common": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "dqXNobZ+/V9n0wk4Is2614fPFXhL5TSE+x0jDIHwcJ7pB5Pn3gD3MMDjHpV4Rq7EDyzIx980cvBOqQ0PdyWMzw==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "kVNJ5GUdo/AeJZNApSHAJnLE6fdNHKrreibPoGRLsxV8zP6YOWBox9ogfBgITTNaQj6AAstjudn+zWk4SGZ46g==",
         "dependencies": {
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7"
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.Load": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "T9RaHjGH4UUwAzVgNAYIjqHm9f2ycL0KocMPiyqQKE7rF0o31SUjtSWGlxLjr0ITUttHwQH051WJnM6o/flbcg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "VYSbH06dwqOz0KFHNzd7vzlXwhpWRXEwdtGIC/zvfw/f70RBzfr+2mcGg7DkA162B3keqNhPThSV1/rXdWsYDw==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.FeatureDetection.ProjectType": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.FeatureDetection.ProjectType": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.FeatureDetection.ProjectType": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "ubp9V7rBTuRNgKhrNFPqmFGlPrFdV18I0OxH2gMzdggYANu7Lb2rp/U+6vk0tUYyPlbMyTYcMZJ79/ZsIvS6Eg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "heNO09IAhGWWDayU+bmt0QFo0fiHjdrJdtC8YDKM/W+qrUYXoZGBN6wmJrrN3Iqiy5fi54Xp11CbbdVrr9ur/g==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Actions": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "tPm0TTDga8Jh5F2Fj60wpeKcll53e1DOvJdgC7OirKd7okIvJdSh43vuIbed3dS91MZ7qM4G7jfEf6uZ57O6tg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "ItRq6n84rjEnaqfLSOoqzhK/g9vtKuKlw58Z8qrhBNY1ncauTcdExmH92KMv7lxbOpqW3KSJP9M509cWcz9wWw==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Models": "2.9.7",
-          "CTA.Rules.ProjectFile": "2.9.7",
-          "CTA.WebForms": "2.9.7",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.ProjectFile": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.WebForms": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.Rules.Analysis": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "7W++wHGBSHcMswPOS8X8hIJB98gvU4F/TIV4eYB46JDaT7HUHP8BC/MlYLAxdXlk3khOzWiVmz2uWPQQ2vOlvA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "yCNRLXZA0U5jz1Dm86OeFiiWM0dP8QZ4qGzCCoPtDqKw3cP5/RB4Yld1VykU8S/y2bQCpye1qmPCVaIRv0egnA==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Common": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "Yn29oIRx13AmYQ2vPIL5IrOq0DxtwHxuRpy4ojklbhBoHZytjA/0VltIX9vUxZ86zX6/PzcV6lM1prxAXuAw3A==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "mz5lzdfUZ50ti9Tn85WiW03goN/Dqv/0Ao0aghvr0o+z5/EqZXg5OtbqHyXPR7plY819Y61DO4vRudd7Fz7BVQ==",
         "dependencies": {
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
       "CTA.Rules.Config": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "o2IkxdBu94pjxDIQj4iwwU+C8aGl42auSr+DoxIssfh7eSXox/PUISy34XCqtZRtYnv/MY8dc3/JeDGy/7jaXA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "NOX3Z4pjf6JtL75Ojd0Mk1cypIUCNmirD+tw7ERvpC6BCNOTFY5kT0yq3zHr0NEtDNYcs/59bUt2fwEi7i4j8A==",
         "dependencies": {
-          "Codelyzer.Analysis": "2.6.2",
-          "Codelyzer.Analysis.Model": "2.6.2",
+          "Codelyzer.Analysis": "2.7.6-alpha-g61536c2540",
+          "Codelyzer.Analysis.Model": "2.7.6-alpha-g61536c2540",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
@@ -284,72 +284,72 @@
       },
       "CTA.Rules.Metrics": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "MN7Q2GbEnf1SSlaDntXerXYWPDjqKnKybT9sMmFxuMzLvSQBqkApaA/mWDNFcyP4TlGa3TsQy6aeISkKmfwueg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "BHrfMcGQk/CbdP1ut4ad1ktsVRMV1CcYfe0yFjQj9FMQCyZXxDChPvRErgj6Q2Y/Y0UTO85LvALmz63wU6MsZQ==",
         "dependencies": {
-          "CTA.FeatureDetection.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.FeatureDetection.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Models": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "BZYUirb+FNpH/0ULM9z7zvHkpBW/fSiOM5wE8VrT3w+Kz0rOHa73dwx/KgQ7LWxnzCM+aO1ZOIq44YldVMMHyQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "rzKahcwVY37C/OiAzQjjZ/JGW0HaHfe5vxMcsnkuodd+4vOg1dZd70dCQ50bj+1Ngqu42fhoZYhGXO87tgDBnw==",
         "dependencies": {
-          "CTA.Rules.Common": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
+          "CTA.Rules.Common": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
           "System.ComponentModel.Annotations": "5.0.0"
         }
       },
       "CTA.Rules.PortCore": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "3q6GFuUZA9nDEZvtVkmmvtcOf1Rt1kstC1Q6+oMb6mrrXIvSktd2N8FGSe4yMxtmA1OXDj/rkNRJ2fQsK0ELiQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "AkM3Ho2/Z/R+C8DBWrOzS5pnxT438SNOKIBFD8yXVBMJfnC3UcC0Omp9CstuP5IeGNXjn8ME8iu57xI7ubB8SA==",
         "dependencies": {
-          "CTA.FeatureDetection": "2.9.7",
-          "CTA.Rules.Update": "2.9.7",
-          "CTA.WebForms": "2.9.7"
+          "CTA.FeatureDetection": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Update": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.WebForms": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.ProjectFile": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "J7Lr22BrTvl1MfN2r93R77wLOp503/ddK1XYRKHdArFFnqeo7X3ydlYST3aDO67Zjd1KAWS0fLrClvD3+R1YgA==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "1IIqz+FLHxoCi15UEC5xMgTEiVxs0jGmvTjQ6Il/xO7E9wborXTPK2rojNcbbzvdRSB3MrkQfPEU/h//kvLcHQ==",
         "dependencies": {
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.RuleFiles": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "0mKZlYfuyLiJcOgFlVaE2qKyXBXMW83BB7Pr7/zMyEi0E8ORC4i5ZPNyS/uxGl7QOs3N+c1Ym90tHhUu/uN81w==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "+QBiE6lR6plBRdtM6CVTLHY8i7Ge+sDwRKlULV/yTX/vMjWfFJny5N1HDmu8g2e3P7RuqeUluZqAWFNVPq94jA==",
         "dependencies": {
-          "CTA.Rules.Actions": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7"
+          "CTA.Rules.Actions": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.Rules.Update": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "ZzH0ZPLg4mu8GgQ96mzTT41ph4BN8L5XqunVHbdmM82VyJr4Cu6c42B0EQSALRqOcTHBtt39Cle6NRX2wv7agQ==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "LEMaWzPJnhOgLY8LZDFXUWPWwvkeO2FKlEdu+gwSe8Obn8eFtTJFdccQJ+0Q1LCrtvqcPTAoPjZXAs/t8nZmvA==",
         "dependencies": {
-          "CTA.Rules.Actions": "2.9.7",
-          "CTA.Rules.Analysis": "2.9.7",
-          "CTA.Rules.Config": "2.9.7",
-          "CTA.Rules.Metrics": "2.9.7",
-          "CTA.Rules.Models": "2.9.7",
-          "CTA.Rules.ProjectFile": "2.9.7",
-          "CTA.Rules.RuleFiles": "2.9.7"
+          "CTA.Rules.Actions": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Analysis": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Config": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Metrics": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.ProjectFile": "2.11.7-alpha-g2ff9aaed0c",
+          "CTA.Rules.RuleFiles": "2.11.7-alpha-g2ff9aaed0c"
         }
       },
       "CTA.WebForms": {
         "type": "Transitive",
-        "resolved": "2.9.7",
-        "contentHash": "oF+QkuvrfLB1ke+vaxlXwYFfMHY5KqZLU0A46/d7hfzkuF9zxnLNIL7V9pel8wpRgAbOM79gPwPeJ8DiVFXvJg==",
+        "resolved": "2.11.7-alpha-g2ff9aaed0c",
+        "contentHash": "qXwHq0qHLd7EWEVJwzHfmtaa8U7uB+YQsQ2zBTqARdrtLnKVUu5Oq34nB6hldMelbJZKSvO6Fh1X6CoaAXWZAg==",
         "dependencies": {
-          "CTA.Rules.Models": "2.9.7",
+          "CTA.Rules.Models": "2.11.7-alpha-g2ff9aaed0c",
           "HtmlAgilityPack": "1.11.42",
           "YamlDotNet": "11.2.1"
         }
@@ -1967,7 +1967,7 @@
       "portingassistant.client.common": {
         "type": "Project",
         "dependencies": {
-          "CTA.Rules.PortCore": "[2.9.7, )",
+          "CTA.Rules.PortCore": "[2.11.7-alpha-g2ff9aaed0c, )",
           "Newtonsoft.Json": "[13.0.1, )",
           "NuGet.Protocol": "[6.5.0, )",
           "Serilog.Extensions.Logging": "[3.0.1, )",

--- a/src/PortingAssistant.Client/Program.cs
+++ b/src/PortingAssistant.Client/Program.cs
@@ -131,7 +131,8 @@ namespace PortingAssistant.Client.CLI
                             SolutionPath = cli.SolutionPath,
                             TargetFramework = cli.Target,
                             RecommendedActions = filteredRecommendedActions.ToList(),
-                            IncludeCodeFix = true
+                            IncludeCodeFix = true,
+                            VisualStudioVersion = solutionSettings.VisualStudioVersion
                         };
 
                         TraceEvent.Start(Log.Logger, $"Applying porting actions to projects in {cli.SolutionPath}");

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
@@ -141,7 +141,7 @@ namespace PortingAssistant.Client.Tests
 
             _apiAnalysisHandlerMock.Reset();
             _apiAnalysisHandlerMock.Setup(analyzer => analyzer.AnalyzeSolution(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<AnalyzerSettings>()))
-                .Returns((string solutionFilePath, List<string> projects, string targetFramework) =>
+                .Returns((string solutionFilePath, List<string> projects, string targetFramework, AnalyzerSettings analyzerSettings) =>
                 {
                     return Task.Run(() => projects.Select(project =>
                     {
@@ -200,7 +200,7 @@ namespace PortingAssistant.Client.Tests
                     }).ToDictionary(k => k.Key, v => v.Value));
                 });
             _apiAnalysisHandlerMock.Setup(analyzer => analyzer.AnalyzeSolutionIncremental(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<AnalyzerSettings>()))
-                .Returns((string solutionFilePath, List<string> projects, string targetFramework) =>
+                .Returns((string solutionFilePath, List<string> projects, string targetFramework, AnalyzerSettings analyzerSettings) =>
                 {
                     return Task.Run(() =>
                     {

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantClientTest.cs
@@ -140,7 +140,7 @@ namespace PortingAssistant.Client.Tests
             _tmpProjectPath = Path.Combine(_tmpSolutionDirectory, "Libraries", "Nop.Core", "Nop.Core.csproj");
 
             _apiAnalysisHandlerMock.Reset();
-            _apiAnalysisHandlerMock.Setup(analyzer => analyzer.AnalyzeSolution(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            _apiAnalysisHandlerMock.Setup(analyzer => analyzer.AnalyzeSolution(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<AnalyzerSettings>()))
                 .Returns((string solutionFilePath, List<string> projects, string targetFramework) =>
                 {
                     return Task.Run(() => projects.Select(project =>
@@ -199,7 +199,7 @@ namespace PortingAssistant.Client.Tests
                         return new KeyValuePair<string, ProjectAnalysisResult>(project, projectAnalysisResult);
                     }).ToDictionary(k => k.Key, v => v.Value));
                 });
-            _apiAnalysisHandlerMock.Setup(analyzer => analyzer.AnalyzeSolutionIncremental(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>()))
+            _apiAnalysisHandlerMock.Setup(analyzer => analyzer.AnalyzeSolutionIncremental(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<AnalyzerSettings>()))
                 .Returns((string solutionFilePath, List<string> projects, string targetFramework) =>
                 {
                     return Task.Run(() =>


### PR DESCRIPTION
#### Description of change
[//]: # Add visualstudioVersion as a parameter in assessment and porting request

#### Issue
[//]: #  TR IDE 2019 and PA IDE 2019 provides incorrect porting result if client machine have both vs2022 and vs2019 installed.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
