### PR TITLE
feat: add regional datastore service

### DIFF
--- a/src/PortingAssistant.Client.Client/DependencyInjection.cs
+++ b/src/PortingAssistant.Client.Client/DependencyInjection.cs
@@ -38,6 +38,7 @@ namespace PortingAssistant.Client.Client
             serviceCollection.AddTransient<ICompatibilityChecker, Compatibility.Core.Checkers.SdkCompatibilityChecker>();
             serviceCollection.AddTransient<ICompatibilityChecker, Compatibility.Core.Checkers.PortabilityAnalyzerCompatibilityChecker>();
             serviceCollection.AddTransient<IHttpService, Compatibility.Common.Utils.HttpService>();
+            serviceCollection.AddTransient<IRegionalDatastoreService, Compatibility.Common.Utils.RegionalDatastoreService>();
         }
 
         public static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()

--- a/src/PortingAssistant.Compatibility.Common/Interface/IRegionalDatastoreService.cs
+++ b/src/PortingAssistant.Compatibility.Common/Interface/IRegionalDatastoreService.cs
@@ -1,0 +1,11 @@
+﻿namespace PortingAssistant.Compatibility.Common.Interface
+{
+    public interface IRegionalDatastoreService
+    {
+        public Task<Stream?> DownloadRegionalS3FileAsync(string fileToDownload, bool isRegionalCall = false);
+
+        public Task<HashSet<string>> ListRegionalNamespacesObjectAsync(bool isRegionalCall = false);
+
+        public Task<Stream> DownloadGitHubFileAsync(string fileToDownload);
+    }
+}

--- a/src/PortingAssistant.Compatibility.Common/Utils/Constants.cs
+++ b/src/PortingAssistant.Compatibility.Common/Utils/Constants.cs
@@ -11,5 +11,11 @@ namespace PortingAssistant.Compatibility.Common.Utils
         public const string DefaultAssessmentTargetFramework = "net6.0";
 
         public const string DestinationKeySuffix = "compatibility-result.json";
+
+        public const string BetaStageName = "beta";
+
+        public const string GammaStageName = "gamma";
+
+        public const string ProdStageName = "prod";
     }
 }

--- a/src/PortingAssistant.Compatibility.Common/Utils/Constants.cs
+++ b/src/PortingAssistant.Compatibility.Common/Utils/Constants.cs
@@ -11,11 +11,5 @@ namespace PortingAssistant.Compatibility.Common.Utils
         public const string DefaultAssessmentTargetFramework = "net6.0";
 
         public const string DestinationKeySuffix = "compatibility-result.json";
-
-        public const string BetaStageName = "beta";
-
-        public const string GammaStageName = "gamma";
-
-        public const string ProdStageName = "prod";
     }
 }

--- a/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
+++ b/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
@@ -1,0 +1,79 @@
+﻿using Amazon;
+using Amazon.S3;
+using PortingAssistant.Compatibility.Common.Interface;
+using Amazon.S3.Model;
+
+namespace PortingAssistant.Compatibility.Common.Utils
+{
+    public class RegionalDatastoreService : IRegionalDatastoreService
+    {
+        private readonly IHttpService _httpService;
+        private readonly AmazonS3Client _s3Client;
+        private readonly bool _isLambdaEnvSetup;
+        private readonly string _regionaS3BucketName;
+
+        public RegionalDatastoreService(IHttpService httpService)
+        {
+            _httpService = httpService;
+            string region = Environment.GetEnvironmentVariable("AWS_REGION");
+            string stage = Environment.GetEnvironmentVariable("stage");
+
+            if (!string.IsNullOrEmpty(region) && !string.IsNullOrEmpty(stage)) 
+            {
+                _isLambdaEnvSetup = true;
+                _regionaS3BucketName = $"portingassistant-datastore-{stage}-{region}";
+                _s3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(region));
+            }
+        }
+
+        public RegionalDatastoreService(IHttpService httpService, AmazonS3Client s3Client, bool isLambdaEnvSetup, string regionaS3BucketName)
+        {
+            _httpService = httpService;
+            _s3Client = s3Client;
+            _isLambdaEnvSetup = isLambdaEnvSetup;
+            _regionaS3BucketName = regionaS3BucketName;
+        }
+
+        public async Task<Stream> DownloadGitHubFileAsync(string fileToDownload)
+        {
+            return await _httpService.DownloadGitHubFileAsync(fileToDownload);
+        }
+
+        public async Task<Stream?> DownloadRegionalS3FileAsync(string fileToDownload, bool isRegionalCall = false)
+        {
+            try 
+            {
+                if (isRegionalCall && _isLambdaEnvSetup)
+                {
+                    GetObjectRequest request = new GetObjectRequest
+                    {
+                        BucketName = _regionaS3BucketName,
+                        Key = fileToDownload
+                    };
+                    using (GetObjectResponse response = await _s3Client.GetObjectAsync(request))
+                    {
+                        Console.WriteLine($"Downloaded {fileToDownload} from " + _regionaS3BucketName);
+                        return response.ResponseStream;
+                    }
+
+                }
+                else
+                {
+                    return await _httpService.DownloadS3FileAsync(fileToDownload);
+                }
+            }
+            catch (Exception ex) 
+            {
+                Console.WriteLine($"fail to download {fileToDownload}. " + ex.Message);
+                return null;
+            }
+            
+        }
+
+        // TODO: This method could be deprecated since sdk namespaces won't change after each feature release
+        public Task<HashSet<string>> ListRegionalNamespacesObjectAsync(bool isRegionalCall = false)
+        {
+            return _httpService.ListNamespacesObjectAsync();
+        }
+    }
+}

--- a/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
+++ b/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
@@ -26,14 +26,6 @@ namespace PortingAssistant.Compatibility.Common.Utils
             }
         }
 
-        public RegionalDatastoreService(IHttpService httpService, AmazonS3Client s3Client, bool isLambdaEnvSetup, string regionaS3BucketName)
-        {
-            _httpService = httpService;
-            _s3Client = s3Client;
-            _isLambdaEnvSetup = isLambdaEnvSetup;
-            _regionaS3BucketName = regionaS3BucketName;
-        }
-
         public async Task<Stream> DownloadGitHubFileAsync(string fileToDownload)
         {
             return await _httpService.DownloadGitHubFileAsync(fileToDownload);

--- a/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
+++ b/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
@@ -23,12 +23,14 @@ namespace PortingAssistant.Compatibility.Common.Utils
             _httpService = httpService;
             _logger = logger;
             string region = Environment.GetEnvironmentVariable("AWS_REGION");
+            string stage = Environment.GetEnvironmentVariable("stage");
 
-            if (!string.IsNullOrEmpty(region)) 
+            if (!string.IsNullOrEmpty(region) && (stage == Constants.BetaStageName || stage == Constants.GammaStageName || stage == Constants.ProdStageName)) 
             {
                 _isLambdaEnvSetup = true;
-                _regionaS3BucketName = $"portingassistant-datastore-{region}";
-                _logger.LogInformation($"Read region from environment: {region}, set S3 bucket name: {_regionaS3BucketName}");
+                _regionaS3BucketName = stage == Constants.ProdStageName ?
+                    $"portingassistant-datastore-{region}" : $"portingassistant-datastore-{stage}-{region}";
+                _logger.LogInformation($"Read stage, region from environment: {stage}, {region}, set S3 bucket name: {_regionaS3BucketName}");
                 _s3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(region));
             }
         }

--- a/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
+++ b/src/PortingAssistant.Compatibility.Common/Utils/RegionalDatastoreService.cs
@@ -22,13 +22,11 @@ namespace PortingAssistant.Compatibility.Common.Utils
             _httpService = httpService;
             _logger = logger;
             string region = Environment.GetEnvironmentVariable("AWS_REGION");
-            string stage = Environment.GetEnvironmentVariable("stage");
 
-            if (!string.IsNullOrEmpty(region) && (stage == Constants.BetaStageName || stage == Constants.GammaStageName || stage == Constants.ProdStageName)) 
+            if (!string.IsNullOrEmpty(region)) 
             {
                 _isLambdaEnvSetup = true;
-                _regionaS3BucketName = stage == Constants.ProdStageName ? 
-                    $"portingassistant-datastore-{region}" : $"portingassistant-datastore-{stage}-{region}"; 
+                _regionaS3BucketName = $"portingassistant-datastore-{region}"; 
                 _s3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(region));
             }
         }

--- a/src/PortingAssistant.Compatibility.Core/Checkers/ExternalCompatibilityChecker.cs
+++ b/src/PortingAssistant.Compatibility.Core/Checkers/ExternalCompatibilityChecker.cs
@@ -9,7 +9,7 @@ namespace PortingAssistant.Compatibility.Core.Checkers
 {
     public class ExternalCompatibilityChecker : ICompatibilityChecker
     {
-        private readonly IHttpService _httpService;
+        private readonly IRegionalDatastoreService _regionalDatastoreService;
         private static readonly int _maxProcessConcurrency = 3;
         private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(_maxProcessConcurrency);
         private ILogger _logger;
@@ -17,10 +17,10 @@ namespace PortingAssistant.Compatibility.Core.Checkers
         public virtual PackageSourceType CompatibilityCheckerType => PackageSourceType.NUGET;
 
         public ExternalCompatibilityChecker(
-            IHttpService httpService,
+            IRegionalDatastoreService regionalDatastoreService,
             ILogger<ExternalCompatibilityChecker> logger)
         {
-            _httpService = httpService;
+            _regionalDatastoreService = regionalDatastoreService;
             _logger = logger;
         }
 
@@ -80,7 +80,7 @@ namespace PortingAssistant.Compatibility.Core.Checkers
                 {
                     HashSet<string>? apis = null; // OriginalDefinition
                     PackageDetails packageDetails = null;
-                    packageDetails = await GetPackageDetailFromS3(fileToDownload, _httpService, apis); 
+                    packageDetails = await GetPackageDetailFromS3(fileToDownload, _regionalDatastoreService, apis); 
 
                     if (packageDetails == null || packageDetails.Name == null || !string.Equals(packageDetails.Name.Trim().ToLower(),
                         packageToDownload.Trim().ToLower(), StringComparison.OrdinalIgnoreCase))
@@ -190,9 +190,9 @@ namespace PortingAssistant.Compatibility.Core.Checkers
         }
 
 
-        public async Task<PackageDetails> GetPackageDetailFromS3(string fileToDownload, IHttpService httpService, HashSet<string> apis = null)
+        public async Task<PackageDetails> GetPackageDetailFromS3(string fileToDownload, IRegionalDatastoreService regionalDatastoreService, HashSet<string> apis = null)
         {
-            using var stream = await httpService.DownloadS3FileAsync(fileToDownload);
+            using var stream = await regionalDatastoreService.DownloadRegionalS3FileAsync(fileToDownload, isRegionalCall: true);
             if (stream == null)
             {
                 return null;

--- a/src/PortingAssistant.Compatibility.Core/Checkers/ExternalCompatibilityChecker.cs
+++ b/src/PortingAssistant.Compatibility.Core/Checkers/ExternalCompatibilityChecker.cs
@@ -80,7 +80,7 @@ namespace PortingAssistant.Compatibility.Core.Checkers
                 {
                     HashSet<string>? apis = null; // OriginalDefinition
                     PackageDetails packageDetails = null;
-                    packageDetails = await GetPackageDetailFromS3(fileToDownload, _regionalDatastoreService, apis); 
+                    packageDetails = await GetPackageDetailFromS3(fileToDownload, apis); 
 
                     if (packageDetails == null || packageDetails.Name == null || !string.Equals(packageDetails.Name.Trim().ToLower(),
                         packageToDownload.Trim().ToLower(), StringComparison.OrdinalIgnoreCase))
@@ -190,9 +190,9 @@ namespace PortingAssistant.Compatibility.Core.Checkers
         }
 
 
-        public async Task<PackageDetails> GetPackageDetailFromS3(string fileToDownload, IRegionalDatastoreService regionalDatastoreService, HashSet<string> apis = null)
+        public async Task<PackageDetails> GetPackageDetailFromS3(string fileToDownload, HashSet<string> apis = null)
         {
-            using var stream = await regionalDatastoreService.DownloadRegionalS3FileAsync(fileToDownload, isRegionalCall: true);
+            using var stream = await _regionalDatastoreService.DownloadRegionalS3FileAsync(fileToDownload, isRegionalCall: true);
             if (stream == null)
             {
                 return null;

--- a/src/PortingAssistant.Compatibility.Core/Checkers/NugetCompatibilityChecker.cs
+++ b/src/PortingAssistant.Compatibility.Core/Checkers/NugetCompatibilityChecker.cs
@@ -9,10 +9,10 @@ namespace PortingAssistant.Compatibility.Core.Checkers
         public override PackageSourceType CompatibilityCheckerType => PackageSourceType.NUGET;
         public ILogger _logger;
         public NugetCompatibilityChecker(
-            IHttpService httpService,
+            IRegionalDatastoreService regionalDatastoreService,
             ILogger<NugetCompatibilityChecker> logger
         )
-            : base(httpService, logger)
+            : base(regionalDatastoreService, logger)
         {
         }
     }

--- a/src/PortingAssistant.Compatibility.Core/Checkers/SdkCompatibilityChecker.cs
+++ b/src/PortingAssistant.Compatibility.Core/Checkers/SdkCompatibilityChecker.cs
@@ -14,9 +14,9 @@ namespace PortingAssistant.Compatibility.Core.Checkers
         public override PackageSourceType CompatibilityCheckerType => PackageSourceType.SDK;
         private ILogger _logger;
         public SdkCompatibilityChecker(
-            IHttpService httpService,
+            IRegionalDatastoreService regionalDatastoreService,
             ILogger<SdkCompatibilityChecker> logger)
-            : base(httpService, logger)
+            : base(regionalDatastoreService, logger)
         {
         }
     }

--- a/src/PortingAssistant.Compatibility.Core/CompatibilityCheckerRecommendationActionHandler.cs
+++ b/src/PortingAssistant.Compatibility.Core/CompatibilityCheckerRecommendationActionHandler.cs
@@ -9,18 +9,18 @@ namespace PortingAssistant.Compatibility.Core
     // The CompatibilityCheckerRecommendationActionHandler checks and gets recommendation action file details ("namespace.json") from the datastore, if any.
     public class CompatibilityCheckerRecommendationActionHandler : ICompatibilityCheckerRecommendationActionHandler
     {
-        private readonly IHttpService _httpService;
+        private readonly IRegionalDatastoreService _regionalDatastoreService;
         private const string _recommendationFileSuffix = ".json";
         private ILogger _logger;
         public PackageSourceType CompatibilityCheckerType => PackageSourceType.RECOMMENDATION;
 
 
         public CompatibilityCheckerRecommendationActionHandler(
-            IHttpService httpService,
+            IRegionalDatastoreService regionalDatastoreService,
             ILogger<CompatibilityCheckerRecommendationActionHandler> logger
             )
         {
-            _httpService = httpService;
+            _regionalDatastoreService = regionalDatastoreService;
             _logger = logger;
         }
 
@@ -39,7 +39,7 @@ namespace PortingAssistant.Compatibility.Core
                 Stream? stream = null;
                 try
                 {
-                    stream = await _httpService.DownloadS3FileAsync(recommendationDownloadPath);
+                    stream = await _regionalDatastoreService.DownloadRegionalS3FileAsync(recommendationDownloadPath, isRegionalCall: true);
                     using var streamReader = new StreamReader(stream);
                     var recommendationFromS3 = JsonConvert.DeserializeObject<RecommendationActionFileDetails>(await streamReader.ReadToEndAsync());
                     recommendationActionDetailsNamespaceDict.Add(namespaceName, recommendationFromS3);

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -208,7 +208,8 @@ namespace PortingAssistant.Client.Tests
         {
             //httpMessageHandler = new Mock<HttpMessageHandler>
             _httpService = new Mock<IHttpService>();
-            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object);
+            var datastoreServiceLoggerMock = new Mock<ILogger<RegionalDatastoreService>>();
+            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object, datastoreServiceLoggerMock.Object);
             _fileSystem = new Mock<IFileSystem>();
         }
 

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -208,8 +208,7 @@ namespace PortingAssistant.Client.Tests
         {
             //httpMessageHandler = new Mock<HttpMessageHandler>
             _httpService = new Mock<IHttpService>();
-            var mockS3Client = new Mock<AmazonS3Client>();
-            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object, mockS3Client.Object, false, "mockS3BucketName");
+            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object);
             _fileSystem = new Mock<IFileSystem>();
         }
 

--- a/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
+++ b/tests/PortingAssistant.Client.UnitTests/PortingAssistantNugetHandlerTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.S3;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -16,6 +17,7 @@ using NUnit.Framework;
 using PortingAssistant.Client.Common.Utils;
 using PortingAssistant.Compatibility.Common.Interface;
 using PortingAssistant.Compatibility.Common.Model;
+using PortingAssistant.Compatibility.Common.Utils;
 using PortingAssistant.Compatibility.Core;
 using PortingAssistant.Compatibility.Core.Checkers;
 using ILogger = NuGet.Common.ILogger;
@@ -26,6 +28,7 @@ namespace PortingAssistant.Client.Tests
     {
         private Mock<IHttpService> _httpService;
         private Mock<IFileSystem> _fileSystem;
+        private IRegionalDatastoreService _regionalDatastoreService;
         private ExternalCompatibilityChecker _externalPackagesCompatibilityChecker;
         private PortabilityAnalyzerCompatibilityChecker _portabilityAnalyzerCompatibilityChecker;
         private SdkCompatibilityChecker _sdkCompatibilityChecker;
@@ -205,6 +208,8 @@ namespace PortingAssistant.Client.Tests
         {
             //httpMessageHandler = new Mock<HttpMessageHandler>
             _httpService = new Mock<IHttpService>();
+            var mockS3Client = new Mock<AmazonS3Client>();
+            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object, mockS3Client.Object, false, "mockS3BucketName");
             _fileSystem = new Mock<IFileSystem>();
         }
 
@@ -248,22 +253,22 @@ namespace PortingAssistant.Client.Tests
 
 
             _externalPackagesCompatibilityChecker = new ExternalCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 NullLogger<ExternalCompatibilityChecker>.Instance
                 );
 
             _portabilityAnalyzerCompatibilityChecker = new PortabilityAnalyzerCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 NullLogger<PortabilityAnalyzerCompatibilityChecker>.Instance
                 );
 
             _sdkCompatibilityChecker = new SdkCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 NullLogger<SdkCompatibilityChecker>.Instance
                 );
 
             _portabilityAnalyzerCompatibilityChecker = new PortabilityAnalyzerCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 NullLogger<PortabilityAnalyzerCompatibilityChecker>.Instance
                 );
 
@@ -367,7 +372,7 @@ namespace PortingAssistant.Client.Tests
         private ExternalCompatibilityChecker GetExternalPackagesCompatibilityChecker()
         {
             var externalChecker = new ExternalCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 NullLogger<ExternalCompatibilityChecker>.Instance
             );
 

--- a/tests/PortingAssistant.Compatibility.Core.Tests/UnitTests/NugetHandlerTest.cs
+++ b/tests/PortingAssistant.Compatibility.Core.Tests/UnitTests/NugetHandlerTest.cs
@@ -70,8 +70,7 @@ namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
         public void OneTimeSetup()
         {
             _httpService = new Mock<IHttpService>();
-            var mockS3Client = new Mock<AmazonS3Client>();
-            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object, mockS3Client.Object, false, "mockS3BucketName");
+            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object);
         }
 
         [SetUp]

--- a/tests/PortingAssistant.Compatibility.Core.Tests/UnitTests/NugetHandlerTest.cs
+++ b/tests/PortingAssistant.Compatibility.Core.Tests/UnitTests/NugetHandlerTest.cs
@@ -70,7 +70,8 @@ namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
         public void OneTimeSetup()
         {
             _httpService = new Mock<IHttpService>();
-            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object);
+            var datastoreServiceLoggerMock = new Mock<ILogger<RegionalDatastoreService>>();
+            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object, datastoreServiceLoggerMock.Object);
         }
 
         [SetUp]

--- a/tests/PortingAssistant.Compatibility.Core.Tests/UnitTests/NugetHandlerTest.cs
+++ b/tests/PortingAssistant.Compatibility.Core.Tests/UnitTests/NugetHandlerTest.cs
@@ -7,6 +7,8 @@ using PortingAssistant.Compatibility.Common.Model;
 using PortingAssistant.Compatibility.Core.Checkers;
 using Assert = NUnit.Framework.Assert;
 using Microsoft.Extensions.Logging;
+using PortingAssistant.Compatibility.Common.Utils;
+using Amazon.S3;
 
 namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
 {
@@ -14,6 +16,7 @@ namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
     public class NugetHandlerTest
     {
         private Mock<IHttpService> _httpService;
+        private IRegionalDatastoreService _regionalDatastoreService;
         private Mock<ICompatibilityCheckerNuGetHandler> _compatibilityCheckerNuGetHandler;
         private NugetCompatibilityChecker _nugetCompatibilityChecker;
         private PortabilityAnalyzerCompatibilityChecker _portabilityAnalyzerCompatibilityChecker;
@@ -67,6 +70,8 @@ namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
         public void OneTimeSetup()
         {
             _httpService = new Mock<IHttpService>();
+            var mockS3Client = new Mock<AmazonS3Client>();
+            _regionalDatastoreService = new RegionalDatastoreService(_httpService.Object, mockS3Client.Object, false, "mockS3BucketName");
         }
 
         [SetUp]
@@ -142,17 +147,17 @@ namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
              _logger = Mock.Of<ILogger<ICompatibilityChecker>>();
 
             _nugetCompatibilityChecker = new NugetCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 Mock.Of<ILogger<NugetCompatibilityChecker>>()
                 );
 
             _portabilityAnalyzerCompatibilityChecker = new PortabilityAnalyzerCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 Mock.Of<ILogger<PortabilityAnalyzerCompatibilityChecker>>()
                 );
 
             _sdkCompatibilityChecker = new SdkCompatibilityChecker(
-                _httpService.Object,
+                _regionalDatastoreService,
                 Mock.Of<ILogger<SdkCompatibilityChecker>>()
                 );
 
@@ -207,7 +212,7 @@ namespace PortingAssistant.Compatibility.Core.Tests.UnitTests
         private NugetCompatibilityChecker GetExternalPackagesCompatibilityChecker()
         {
             var externalChecker = new NugetCompatibilityChecker(
-                _httpService.Object, Mock.Of<ILogger<NugetCompatibilityChecker>>());
+                _regionalDatastoreService, Mock.Of<ILogger<NugetCompatibilityChecker>>());
 
             return externalChecker;
         }


### PR DESCRIPTION
#### Description of change
[//]: # (What are you trying to fix? What did you change)

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)
1. Use `IRegionalDatastoreService` as a wrapper of `IHttpService`. The implementation `RegionalDatastoreService` will route service calls to S3 client, and non-service calls to Http service.
2. Route calls to IHttpService if service Lambda environment isn't setup properly, which prevents introducing breaking changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
